### PR TITLE
Layout fixes for windows

### DIFF
--- a/static/css/iframe.css
+++ b/static/css/iframe.css
@@ -18,7 +18,7 @@
 /* For LESS THAN 641px wide */
 @media (max-width : 640px) {
   #innerdocbody{
-    padding-top:0px !important;
+    padding-top:77px !important;
     margin-left:0px !important;
   }
   #sidediv{
@@ -67,7 +67,7 @@
 @media (min-width: 542px) and (max-width : 691px) {
   #innerdocbody > div {
     padding-left: 67px; /* left margin gets only enough to display scene number */
-    padding-right: calc(100% - 511px);
+    padding-right: calc(100% - 511px); /* 444 + 67 (padding-left) */
   }
 }
 

--- a/static/css/iframe.css
+++ b/static/css/iframe.css
@@ -66,8 +66,8 @@
    enough to draw page outline: */
 @media (min-width: 542px) and (max-width : 691px) {
   #innerdocbody > div {
-    padding-left: 67px; /* left margin gets only enough to display scene number */
-    padding-right: calc(100% - 511px); /* 444 + 67 (padding-left) */
+    padding-left: 77px; /* left margin gets only enough to display scene number and SM icon */
+    padding-right: calc(100% - 521px); /* 444 + 77 (padding-left) */
   }
 }
 

--- a/static/css/pagination.css
+++ b/static/css/pagination.css
@@ -4,7 +4,7 @@
   line-height: 16px;
 }
 
-@media (min-width : 636px) {
+@media (min-width: 464px) {
   /* Removes top margin for elements after page breaks */
   #innerdocbody.breakPages div.beforePageBreak + div heading,
   #innerdocbody.breakPages div.beforePageBreak + div action,
@@ -71,7 +71,7 @@
   #innerdocbody.breakPages div splitPageBreak:before,
   #innerdocbody.breakPages div nonSplitPageBreak:before {
     content: "";
-    margin-right:-85px;
+    margin-right:-128px;
     background-color:#f7f7f7;
     float: right;
     cursor: default;

--- a/static/js/fixSmallZooms.js
+++ b/static/js/fixSmallZooms.js
@@ -13,7 +13,7 @@ exports.STYLES_UPDATED = 'STYLES_UPDATED.ep_script_page_view';
 // A4
 var REGULAR_LINES_PER_PAGE = 58;
 
-var LARGE_SCREEN_MIN_WIDTH = 636;
+var LARGE_SCREEN_MIN_WIDTH = 464; // see pagination.css
 
 var DEFAULT_PADDING_LEFT  = 117;
 var DEFAULT_PADDING_RIGHT = 78;
@@ -83,7 +83,7 @@ var updatePageWidth = function(newCharProportion) {
   // this was moved from CSS file to here, so it can have a dynamic value
   var pageStyle      = ".outerPV { width: " + newPageWidth + "px !important; }";
   // add some px for safety (to avoid a vertical line to be displayed on 25% or 33%)
-  var pageBreakStyle = "splitPageBreak:before, nonSplitPageBreak:before { width: " + (newPageWidth + 11) + "px !important; }";
+  var pageBreakStyle = "splitPageBreak:before, nonSplitPageBreak:before { width: " + (newPageWidth + 50) + "px !important; }";
 
   // overwrite current style for page width
   // Note: we cannot change .outerPV width using jQuery.css() because Etherpad already overwrites this


### PR DESCRIPTION
- Do not hide top margin on small screens
- Ensure left margin has space for SM icons
- Show page breaks for all screens where page margins are shown