### PR TITLE
[refactor] Do not use Set

### DIFF
--- a/static/js/paginationLinesChanged.js
+++ b/static/js/paginationLinesChanged.js
@@ -4,16 +4,16 @@ var utils = require('./utils');
 
 var linesChanged = {
   rep: undefined,
-  lines: new Set(),
+  lines: {},
   initialized: false,
 
   add: function(lineNumber) {
-    this.lines.add(lineNumber);
+    this.lines[lineNumber] = true;
   },
 
   reset: function(rep) {
     this.rep = rep;
-    this.lines.clear();
+    this.lines = {};
     this.initialized = true;
   },
 };
@@ -38,13 +38,13 @@ exports.markLineAsChanged = function(lineNumber) {
 }
 
 exports.hasLinesChanged = function() {
-  return linesChanged.lines.size > 0;
+  return _(linesChanged.lines).keys().size > 0;
 }
 
 exports.minLineChanged = function() {
-  return _.min(Array.from(linesChanged.lines));
+  return _(_(linesChanged.lines).keys()).min();
 }
 
 exports.lineWasChanged = function(lineNumber) {
-  return linesChanged.lines.has(lineNumber);
+  return linesChanged.lines[lineNumber];
 }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,4 +1,5 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var _ = require('ep_etherpad-lite/static/js/underscore');
 var Security = require('ep_etherpad-lite/static/js/security');
 
 var EMPTY_CHARACTER_NAME = "empty";
@@ -265,13 +266,13 @@ exports.cleanHelperLines = function($helperLines) {
   });
 }
 
-var pageBreakTags = new Set(["more", "contdLine", "pagenumber"]);
+var pageBreakTags = ["more", "contdLine", "pagenumber"];
 var pageBreakTagsSelector;
 exports.registerPageBreakTag = function(tagName) {
-  pageBreakTags.add(tagName);
+  pageBreakTags.push(tagName);
 
   // cache selector for faster processing
-  pageBreakTagsSelector = Array.from(pageBreakTags).join(",");
+  pageBreakTagsSelector = _(pageBreakTags).unique().join(",");
 }
 
 var getPageBreakTagsSelector = function() {


### PR DESCRIPTION
Avoid issues with browsers that do not support Set yet, use a common JS
object instead. This avoids breaking integration tests with TK.