### PR TITLE
[perf] Avoid Etherpad to hang while pasting large contents

### DIFF
--- a/static/css/pagination.css
+++ b/static/css/pagination.css
@@ -6,11 +6,11 @@
 
 @media (min-width: 464px) {
   /* Removes top margin for elements after page breaks */
-  #innerdocbody.breakPages div.beforePageBreak + div heading,
-  #innerdocbody.breakPages div.beforePageBreak + div action,
-  #innerdocbody.breakPages div.beforePageBreak + div character,
-  #innerdocbody.breakPages div.beforePageBreak + div transition,
-  #innerdocbody.breakPages div.beforePageBreak + div shot {
+  div.aferPageBreak heading,
+  div.aferPageBreak action,
+  div.aferPageBreak character,
+  div.aferPageBreak transition,
+  div.aferPageBreak shot {
     margin-top: 0px;
   }
 
@@ -18,35 +18,26 @@
      page breaks.
      This is necessary because first line is originally on top of a page (so without any margin),
      but when it is cloned it is added after a regular line (so it would have a margin) */
-  #innerdocbody.breakPages div.cloned.cloned__first heading {
+  div.cloned.cloned__first heading {
     margin-top: 0;
   }
 
-  #innerdocbody.breakPages div splitPageBreak,
-  #innerdocbody.breakPages div nonSplitPageBreak,
-  #innerdocbody.breakPages div contdLine,
-  #innerdocbody.breakPages div more,
-  #innerdocbody.breakPages div contd {
+  div splitPageBreak,
+  div nonSplitPageBreak,
+  div contdLine,
+  div more,
+  div contd {
     display: block;
   }
 
-  #innerdocbody.breakPages div more:before,
-  #innerdocbody.breakPages div contd:before,
-  #innerdocbody.breakPages div contd:after {
+  div more:before,
+  div contd:before,
+  div contd:after {
     float: left; /* need this to not allow caret to be placed on element */
     cursor: default;
   }
 
-  /* WARNING there are other styles for MORE and CONT'D dynamically set on fixSmallZooms.js */
-  #innerdocbody.breakPages div more:before {
-    content: "(MORE)";
-  }
-  #innerdocbody.breakPages[lang=pt-br] div more:before {
-    content: "(MAIS)";
-  }
-
-  #innerdocbody.breakPages div contd:before {
-    content: attr(data-character);
+  div contd:before {
     text-transform: uppercase;
 
     /* the following attributes are necessary to display ellipsis when character name is too long */
@@ -56,21 +47,37 @@
     /* WARNING this is set on fixSmallZooms.js
     max-width: calc(100% - 64px - 222px); */ /*64px: CONT'D width; 222px: CONT'D right margin */
   }
-  #innerdocbody.breakPages div contd:after {
-    content: "(CONT'D)";
-
+  div contd:after {
     /* the following attributes are necessary to display ellipsis when character name is too long */
     text-align: right;
     /* WARNING this is set on fixSmallZooms.js
     width: 64px;*/
   }
-  #innerdocbody.breakPages[lang=pt-br] div contd:after {
+
+  /* [perf] do not build pseudo-elements while on paste */
+  /* WARNING there are other styles for MORE and CONT'D dynamically set on fixSmallZooms.js */
+  #innerdocbody:not(.pasting)             div more:before {
+    content: "(MORE)";
+  }
+  #innerdocbody:not(.pasting)[lang=pt-br] div more:before {
+    content: "(MAIS)";
+  }
+  #innerdocbody:not(.pasting)             div contd:before {
+    content: attr(data-character);
+  }
+  #innerdocbody:not(.pasting)             div contd:after {
+    content: "(CONT'D)";
+  }
+  #innerdocbody:not(.pasting)[lang=pt-br] div contd:after {
     content: "(CONT.)";
   }
-
-  #innerdocbody.breakPages div splitPageBreak:before,
-  #innerdocbody.breakPages div nonSplitPageBreak:before {
+  #innerdocbody:not(.pasting)             div splitPageBreak:before,
+  #innerdocbody:not(.pasting)             div nonSplitPageBreak:before {
     content: "";
+  }
+
+  div splitPageBreak:before,
+  div nonSplitPageBreak:before {
     margin-right:-128px;
     background-color:#f7f7f7;
     float: right;
@@ -95,7 +102,7 @@
   }
 
   /* leave room for page break on line at the end of the page */
-  #innerdocbody.breakPages div.beforePageBreak {
+  div.beforePageBreak {
     /* All values of calc are from page break */
     /* 10px: height; 48px: margin-top and margin-bottom; 1px: border-top and border-bottom;
        2px: Bug fix: some zoom values mess up with border (they don't have 1px), so we
@@ -104,35 +111,39 @@
   }
 
   /* hide ")" from 1st half of split parenthetical: */
-  #innerdocbody.breakPages div.firstHalf parenthetical:after {
+  div.firstHalf parenthetical:after {
     content: ' ';
     margin-right: 0;
   }
   /* hide "(" from 2nd half of split parenthetical: */
-  #innerdocbody.breakPages div.firstHalf + div parenthetical:before {
+  div.secondHalf parenthetical:before {
     content: ' ';
     margin-left: 0;
   }
 
   /* special style used on the calculation of split lines: hide both "()" of cloned parenthetical */
-  #innerdocbody.breakPages div.clone parenthetical:after,
-  #innerdocbody.breakPages div.clone parenthetical:before {
+  /* FIXME do we still need this, after pagination algorithm is changed to not use cloned lines? */
+/*
+  div.clone parenthetical:after,
+  div.clone parenthetical:before {
     content: ' ';
     margin-left: 0;
     margin-right: 0;
   }
+*/
 
   /* page number: */
-  #innerdocbody.breakPages div pagenumber {
+  div pagenumber {
     margin-top: -32px;
     margin-right: 4px;
     float: right;
   }
-  #innerdocbody.breakPages div pagenumber:before {
+  /* [perf] do not build pseudo-elements while on paste */
+  #innerdocbody:not(.pasting) div pagenumber:before {
     margin-right: 5px;
     content: attr(data-page-number) ".";
   }
-  #innerdocbody.breakPages div calculating {
+  div calculating {
     float: right;
   }
 
@@ -145,13 +156,14 @@
     z-index:150;
   }
 
-  div.lastPaginated ~ div calculating:before {
+  /* [perf] do not build pseudo-elements while on paste */
+  #innerdocbody:not(.pasting) div.lastPaginated ~ div calculating:before {
     content: "\e80e";
   }
 
   /* Prevent the last line from sticking on the bottom of the viewport.
      Useful for a smooth scrolling when editing last line. */
-  #innerdocbody > div:last-of-type {
-    margin-bottom: 40px;
+  #innerdocbody {
+    padding-bottom: 40px;
   }
 }

--- a/static/js/cssOptimization.js
+++ b/static/js/cssOptimization.js
@@ -1,0 +1,37 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var _ = require('ep_etherpad-lite/static/js/underscore');
+
+var utils = require('./utils');
+var detailedLinesChangedListener = require('ep_script_scene_marks/static/js/detailedLinesChangedListener');
+
+var BEFORE_PAGE_BREAK_CLASS = 'beforePageBreak';
+var AFTER_PAGE_BREAK_CLASS = 'afterPageBreak';
+
+exports.init = function() {
+  initializePaginationClass();
+  updatePaginationClassWhenLinesWithPageBreaksAreChanged();
+}
+
+var initializePaginationClass = function() {
+  var $allLinesWithPageBreaks = utils.getPadInner().find('.' + BEFORE_PAGE_BREAK_CLASS);
+  updatePageBreakClass($allLinesWithPageBreaks.toArray());
+}
+
+var updatePaginationClassWhenLinesWithPageBreaksAreChanged = function() {
+  detailedLinesChangedListener.onLinesAddedOrRemoved(function(linesChanged) {
+    var linesWithPageBreaks = getLinesWithPageBreaks(linesChanged.linesAdded);
+    updatePageBreakClass(linesWithPageBreaks);
+  });
+}
+
+var getLinesWithPageBreaks = function(linesChanged) {
+  return _(linesChanged).filter(function(line) {
+    return _(line.classList).contains(BEFORE_PAGE_BREAK_CLASS);
+  });
+}
+
+var updatePageBreakClass = function(linesWithPageBreaks) {
+  _(linesWithPageBreaks).each(function(lineWithPageBreak) {
+    $(lineWithPageBreak).next().addClass(AFTER_PAGE_BREAK_CLASS);
+  });
+}

--- a/static/js/cssOptimization.js
+++ b/static/js/cssOptimization.js
@@ -7,31 +7,37 @@ var detailedLinesChangedListener = require('ep_script_scene_marks/static/js/deta
 var BEFORE_PAGE_BREAK_CLASS = 'beforePageBreak';
 var AFTER_PAGE_BREAK_CLASS = 'afterPageBreak';
 
+var FIRST_HALF_CLASS = 'firstHalf';
+var SECOND_HALF_CLASS = 'secondHalf';
+
 exports.init = function() {
-  initializePaginationClass();
-  updatePaginationClassWhenLinesWithPageBreaksAreChanged();
+  initializePaginationClass(BEFORE_PAGE_BREAK_CLASS, AFTER_PAGE_BREAK_CLASS);
+  initializePaginationClass(FIRST_HALF_CLASS, SECOND_HALF_CLASS);
+
+  updatePaginationClassWhenLinesWithPageBreaksAreChanged(BEFORE_PAGE_BREAK_CLASS, AFTER_PAGE_BREAK_CLASS);
+  updatePaginationClassWhenLinesWithPageBreaksAreChanged(FIRST_HALF_CLASS, SECOND_HALF_CLASS);
 }
 
-var initializePaginationClass = function() {
-  var $allLinesWithPageBreaks = utils.getPadInner().find('.' + BEFORE_PAGE_BREAK_CLASS);
-  updatePageBreakClass($allLinesWithPageBreaks.toArray());
+var initializePaginationClass = function(sourceClass, targetClass) {
+  var $allLinesWithPageBreaks = utils.getPadInner().find('.' + sourceClass);
+  updatePageBreakClass($allLinesWithPageBreaks.toArray(), targetClass);
 }
 
-var updatePaginationClassWhenLinesWithPageBreaksAreChanged = function() {
+var updatePaginationClassWhenLinesWithPageBreaksAreChanged = function(sourceClass, targetClass) {
   detailedLinesChangedListener.onLinesAddedOrRemoved(function(linesChanged) {
-    var linesWithPageBreaks = getLinesWithPageBreaks(linesChanged.linesAdded);
-    updatePageBreakClass(linesWithPageBreaks);
+    var linesWithPageBreaks = getLinesWithPageBreaks(linesChanged.linesAdded, sourceClass);
+    updatePageBreakClass(linesWithPageBreaks, targetClass);
   });
 }
 
-var getLinesWithPageBreaks = function(linesChanged) {
+var getLinesWithPageBreaks = function(linesChanged, sourceClass) {
   return _(linesChanged).filter(function(line) {
-    return _(line.classList).contains(BEFORE_PAGE_BREAK_CLASS);
+    return _(line.classList).contains(sourceClass);
   });
 }
 
-var updatePageBreakClass = function(linesWithPageBreaks) {
+var updatePageBreakClass = function(linesWithPageBreaks, targetClass) {
   _(linesWithPageBreaks).each(function(lineWithPageBreak) {
-    $(lineWithPageBreak).next().addClass(AFTER_PAGE_BREAK_CLASS);
+    $(lineWithPageBreak).next().addClass(targetClass);
   });
 }

--- a/static/js/pagination.js
+++ b/static/js/pagination.js
@@ -14,6 +14,7 @@ var undoElementType            = require('./undoElementType');
 var calculatingPageNumberIcons = require('./calculatingPageNumberIcons');
 var paginationCalculation      = require('./paginationPageBreaksCalculation');
 var paginationLineObserver     = require('./paginationLineObserver');
+var cssOptimization            = require('./cssOptimization');
 
 var isInTheMiddleOfASceneMarkVisibilityToggle = require("ep_script_scene_marks/static/js/sceneMarkVisibility").isInTheMiddleOfASceneMarkVisibilityToggle;
 
@@ -143,6 +144,9 @@ exports.aceEditEvent = function(hook, context) {
 
     // when pad is loaded, it marks all lines as changed, so we need to reset counter
     paginationLinesChanged.reset(context.rep);
+
+    // need to be after pad is loaded, otherwise some classes may be overwritten
+    cssOptimization.init();
   }
   // repagination didn't finish, need to continue (but only if I was the one who started it,
   // otherwise we'll get errors when 2 users have the same pad opened)


### PR DESCRIPTION
Simplify CSS selector, so paste of large scripts won't take too long to complete or make Etherpad be "hanged" for some minutes. Also simplify other CSS selectors for the same reason.

Use new fixSmallZooms framework, defined by ep_SE.

Fix part of https://trello.com/c/3cBqMCx8/1082.

This is part of a set of PRs that were created together:
  * [on ep_script_scene_marks](https://github.com/storytouch/ep_script_scene_marks/pull/31)
  * [on ep_script_elements](https://github.com/storytouch/ep_script_elements/pull/16)
  * [on ep_script_toggle_view](https://github.com/storytouch/ep_script_toggle_view/pull/26)
  * [on ep_script_touches](https://github.com/storytouch/ep_script_touches/pull/37)
  * [on ep_script_page_view](https://github.com/storytouch/ep_script_page_view/pull/8)
  * [on ep_script_copy_cut_paste](https://github.com/storytouch/ep_script_copy_cut_paste/pull/5)
