### PR TITLE
[refactor] Remove unused CSS for larger screens

### DIFF
--- a/static/css/page_view.css
+++ b/static/css/page_view.css
@@ -1,47 +1,10 @@
+.outerBackground{
+  width:100%;
+}
+
 #editorcontainerbox{
-/* Removed as it messed up the editbar styling */
-/*
-  background-color:#F7F7F7;
-*/
+  top:0px;
 }
-
-@media (min-width: 712px) {
-  #editorcontainer.page_view {
-    background-color: #f7f7f7;
-    text-align: center;
-    top:37px;
-  }
-
-  #editorcontainerbox{
-/*
-    background-color:#f7f7f7;
-*/
-    top:0px;
-  }
-
-  #editorcontainer .page_view{
-    top:0px;
-    padding-top:20px;
-  }
-
-  #editorloadingbox{
-    margin-top:100px;
-  }
-
+#editorcontainer{
+  top:0px;
 }
-
-@media (max-width: 711px) {
-
-  .outerBackground{
-    width:100%;
-  }
-
-  #editorcontainerbox{
-    top:0px;
-  }
-  #editorcontainer{
-    top:0px;
-  }
-
-}
-


### PR DESCRIPTION
On TK, we only show the editor on the max-width mode (no side borders), which is `642px`. So it doesn't make sense to keep any CSS style for screens larger than that.

Let's move this code back when we implement the feature to show editor on other page views (full-page, for example).