### PR TITLE
[refactor] Bundle CSS file

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,7 +4,7 @@
       "name": "page_view",
       "client_hooks": {
         "postAceInit": "ep_script_page_view/static/js/index",
-        "aceEditorCSS": "ep_script_page_view/static/js/index",
+        "aceEditorCSS": "ep_script_page_view/static/js/aceEditorCSS",
         "aceInitialized": "ep_script_page_view/static/js/pagination",
         "aceAttribsToClasses": "ep_script_page_view/static/js/pagination",
         "acePostWriteDomLineHTML": "ep_script_page_view/static/js/pagination",

--- a/static/js/aceEditorCSS.js
+++ b/static/js/aceEditorCSS.js
@@ -1,0 +1,6 @@
+exports.aceEditorCSS = function(hook_name, cb) {
+  return [
+    '/ep_script_page_view/static/css/iframe.css',
+    '/ep_script_page_view/static/css/pagination.css',
+  ];
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -140,7 +140,3 @@ function getParam(sname) {
   }
   return sval;
 }
-
-exports.aceEditorCSS = function(hook_name, cb) {
-  return ["/ep_script_page_view/static/css/iframe.css", "/ep_script_page_view/static/css/pagination.css"];
-}


### PR DESCRIPTION
Extract aceEditorCSS into a separated file, so this plugin can have its CSS files bundled.

Implement part of https://trello.com/c/lfLjqYD4/1672.