### PR TITLE
[fix] Unify codes to change line type on utils.js of ep_SE

### DIFF
--- a/static/js/paginationSplit.js
+++ b/static/js/paginationSplit.js
@@ -4,6 +4,7 @@ var randomString         = require('ep_etherpad-lite/static/js/pad_utils').rando
 var utils                = require('./utils');
 var paginationPageNumber = require('./paginationPageNumber');
 var paginationNonSplit   = require('./paginationNonSplit');
+var scriptElementUtils   = require('ep_script_elements/static/js/utils');
 
 var PAGE_BREAKS_ATTRIB                     = "splitPageBreak";
 var PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB = "splitPageBreakWithMoreAndContd";
@@ -539,9 +540,7 @@ var splitLine = function(splitPosition, attributeManager, editorInfo, rep) {
 }
 
 var setTypeOfSecondHalfOfLine = function(lineNumber, lineType, attributeManager) {
-  if (lineType) {
-    attributeManager.setAttributeOnLine(lineNumber+1, 'script_element', lineType);
-  }
+  scriptElementUtils.updateLineType(lineNumber + 1, attributeManager, lineType);
 }
 
 var addPageBreakBetweenLines = function(splitPosition, pageNumber, attributeManager) {

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -2,6 +2,8 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var Security = require('ep_etherpad-lite/static/js/security');
 
+var scriptElementUtils = require('ep_script_elements/static/js/utils');
+
 var EMPTY_CHARACTER_NAME = "empty";
 
 var SCRIPT_ELEMENTS_SELECTOR = "heading, action, character, parenthetical, dialogue, transition, shot";
@@ -56,7 +58,7 @@ exports.typeOf = function($line) {
 }
 
 exports.getLineTypeOf = function(lineNumber, attributeManager) {
-  return attributeManager.getAttributeOnLine(lineNumber, "script_element");
+  return scriptElementUtils.getLineType(lineNumber, attributeManager);
 }
 
 var bottomOf = function($targetLine) {


### PR DESCRIPTION
Create functions on utils.js of ep_SE to add or remove `'script_element'` line attrib, and use them around the plugins.

This is part of the fix for [this bug](https://trello.com/c/IPSeZBxs/1703).

PRs that are part of this change:

- https://github.com/storytouch/ep_script_elements/pull/31
- https://github.com/storytouch/ep_script_scene_marks/pull/64
- https://github.com/storytouch/ep_script_page_view/pull/14
- https://github.com/storytouch/ep_script_autocomp/pull/12
- https://github.com/storytouch/ep_script_element_transitions/pull/9