### PR TITLE
[feat] Code cleanup + enable/disable pagination via URL & API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-deploy:
-  api_key:
-    secure: crKar9Ul+XEpiPQisz+LR2xLU9QkiV72MvXY2zrNU86qpl2HDqxwEZ9L395+3F4EdQAtmvf7duVMQK0BVmMrXNC5IVPFByUG2rBieX/xX3Vgi2JUZHH9fShf0MysHnCcJPmKY8BHhughvP6ad8UrI+CGqjcWzxgzKzF3gJfogoo=
-  provider: npm
-  email: john@mclear.co.uk

--- a/ep.json
+++ b/ep.json
@@ -14,10 +14,7 @@
         "aceEditEvent": "ep_script_page_view/static/js/pagination"
       },
       "hooks": {
-        "eejsBlock_mySettings": "ep_script_page_view/page_view",
-        "eejsBlock_styles": "ep_script_page_view/page_view",
-        "eejsBlock_dd_insert" : "ep_script_page_view/page_view",
-        "eejsBlock_dd_view" : "ep_script_page_view/page_view"
+        "eejsBlock_styles": "ep_script_page_view/page_view"
       }
     },
     {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-var eejs = require('ep_etherpad-lite/node/eejs/');
-var Changeset = require("ep_etherpad-lite/static/js/Changeset");
-exports.eejsBlock_editbarMenuLeft = function (hook_name, args, cb) {
-  args.content = args.content + eejs.require("ep_script_page_view/templates/editbarButtons.ejs");
-  return cb();
-}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,3 +1,0 @@
-{
-  "ep_script_page_view.pagination" : "Automatic pagination"
-}

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,3 +1,0 @@
-{
-  "ep_script_page_view.pagination" : "Paginação automática"
-}

--- a/page_view.js
+++ b/page_view.js
@@ -1,21 +1,3 @@
-var eejs = require('ep_etherpad-lite/node/eejs/');
-var settings = require('ep_etherpad-lite/node/utils/Settings');
-var checked_state = '';
-
-exports.eejsBlock_mySettings = function (hook_name, args, cb) {
-  if (settings.ep_page_view_default) checked_state = 'checked';
-  args.content = args.content + eejs.require('ep_script_page_view/templates/page_view_entry.ejs', {checked : checked_state});
-  return cb();
-}
-
 exports.eejsBlock_styles = function (hook_name, args, cb){
   args.content = args.content + '<link href="../static/plugins/ep_script_page_view/static/css/page_view.css" rel="stylesheet">';
-}
-
-exports.eejsBlock_dd_insert = function (hook_name, args, cb){
-  args.content = args.content + eejs.require('ep_script_page_view/templates/page_view_menu.ejs', {checked : checked_state});
-}
-
-exports.eejsBlock_dd_view = function (hook_name, args, cb){
-  args.content = args.content + "<li><a href='#' onClick='$(\"#options-pageview\").click();'>Page View</a></li>";
 }

--- a/static/js/calculatingPageNumberIcons.js
+++ b/static/js/calculatingPageNumberIcons.js
@@ -3,13 +3,13 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var utils = require('./utils');
 
 exports.hideAll = function() {
-  var $lastPageBreakOfPreviousCycle = utils.getPadInner().find("div.lastPaginated");
-  $lastPageBreakOfPreviousCycle.removeClass("lastPaginated");
+  var $lastPageBreakOfPreviousCycle = utils.getPadInner().find('div.lastPaginated');
+  $lastPageBreakOfPreviousCycle.removeClass('lastPaginated');
 }
 
 exports.displayAllAfterLine = function(lineNumber, rep) {
   exports.hideAll();
 
   var $lastPageBreakOfThisCycle = $(utils.getDOMLineFromLineNumber(lineNumber, rep));
-  $lastPageBreakOfThisCycle.addClass("lastPaginated");
+  $lastPageBreakOfThisCycle.addClass('lastPaginated');
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,87 +1,53 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
-var _ = require('ep_etherpad-lite/static/js/underscore');
-var padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
 
 var utils = require('./utils');
 var paginationCalculation = require('./pagination');
 
-var COOKIE_PREF_NAME = 'automaticPagination';
 var LINE_NUMBERS_ENABLED_OUTER_CLASS = 'lineNumbersAndPageView';
 var LINE_NUMBERS_ENABLED_INNER_CLASS = 'innerPVlineNumbers';
 
-exports.postAceInit = function(hook, context){
-  var $outerIframeContents = utils.getPadOuter();
-  var $innerIframe = $outerIframeContents.find('iframe');
-  var $innerdocbody = utils.getPadInner().find("#innerdocbody");
+var API_MESSAGE = 'pagination_enabled';
 
-  var automaticPagination = {
-    enable: function() {
-      clientVars.plugins.plugins.ep_script_page_view.pageBreakEnabled = true;
-      $innerdocbody.addClass('breakPages');
-    },
-
-    disable: function() {
-      clientVars.plugins.plugins.ep_script_page_view.pageBreakEnabled = false;
-      $innerdocbody.removeClass('breakPages');
-    }
-  }
-
-  var pageView = {
-    enable: function() {
-      clientVars.plugins.plugins.ep_script_page_view.enabled = true;
-
-      $('#editorcontainer, iframe').addClass('page_view');
-      $innerIframe.addClass('outerPV');
-      $outerIframeContents.find('#outerdocbody').addClass("outerBackground");
-      $innerdocbody.addClass('innerPV').css("margin-left","0px");
-
-      $('#ep_page_ruler').show();
-
-      adjustToLineNumberSetting();
-    },
-
-    disable: function() {
-      clientVars.plugins.plugins.ep_script_page_view.enabled = false;
-
-      $('#editorcontainer, iframe').removeClass('page_view');
-      $innerIframe.removeClass('outerPV');
-      $outerIframeContents.find('#outerdocbody').removeClass("outerBackground");
-      $innerdocbody.removeClass('innerPV').css("margin-left","-100px");
-
-      $('#ep_page_ruler').hide();
-
-      adjustToLineNumberSetting();
-    }
-  }
-
-  /* init */
-  setupPageViewInitialSetting(pageView);
-  setupPageBreakInitialSetting(automaticPagination);
+exports.postAceInit = function(hook, context) {
+  listenToAPICallsToTogglePagination();
+  setupPageViewInitialSetting();
+  loadPageBreakInitialSettingFromURL();
 
   /* on click */
-  $('#options-pagination').on('click', function() {
-    // we only set pagination cookie if user intentionally changed the setting
-    if($('#options-pagination').is(':checked')) {
-      automaticPagination.enable();
-      paginationCalculation.enable();
-      padcookie.setPref(COOKIE_PREF_NAME, true);
-    } else {
-      automaticPagination.disable();
-      paginationCalculation.disable();
-      padcookie.setPref(COOKIE_PREF_NAME, false);
-    }
-  });
-
   $('#options-linenoscheck').on('click', function() {
     adjustToLineNumberSetting();
   });
 };
 
-function adjustToLineNumberSetting() {
+var listenToAPICallsToTogglePagination = function() {
+  // listen to outbound calls of this API
+  window.addEventListener('message', function(e) {
+    if (e.data.type === API_MESSAGE) {
+      togglePagination(e.data.paginationEnabled);
+    }
+  });
+}
+
+var enablePagination = function() {
+  togglePagination(true);
+  paginationCalculation.enable();
+}
+
+var disablePagination = function() {
+  togglePagination(false);
+  paginationCalculation.disable();
+}
+
+var togglePagination = function(paginationEnabled) {
+  utils.getPluginProps().pageBreakEnabled = paginationEnabled;
+  utils.getPadInner().find('#innerdocbody').toggleClass('breakPages', paginationEnabled);
+}
+
+var adjustToLineNumberSetting = function() {
   var $lineNumbers = utils.getPadOuter().find('#sidediv');
   var $innerdocbody = utils.getPadInner().find('#innerdocbody');
 
-  if(lineNumbersAreEnabled()) {
+  if (lineNumbersAreEnabled()) {
     $lineNumbers.addClass(LINE_NUMBERS_ENABLED_OUTER_CLASS);
     $innerdocbody.addClass(LINE_NUMBERS_ENABLED_INNER_CLASS);
   } else {
@@ -89,54 +55,27 @@ function adjustToLineNumberSetting() {
     $innerdocbody.removeClass(LINE_NUMBERS_ENABLED_INNER_CLASS);
   }
 }
-function lineNumbersAreEnabled() {
+var lineNumbersAreEnabled = function() {
   return $('#options-linenoscheck').is(':checked');
 }
 
-function setupPageViewInitialSetting(pageView) {
-  // page view is always enabled
-  pageView.enable();
+var setupPageViewInitialSetting = function() {
+  $('#editorcontainer, iframe').addClass('page_view');
+  utils.getPadOuter().find('iframe').addClass('outerPV');
+  utils.getPadOuter().find('#outerdocbody').addClass('outerBackground');
+  utils.getPadInner().find('#innerdocbody').addClass('innerPV').css('margin-left', '0px');
+
+  $('#ep_page_ruler').show();
+
+  adjustToLineNumberSetting();
 }
 
-function setupPageBreakInitialSetting(automaticPagination) {
-  var $paginationSetting = $('#options-pagination');
-
-  // Temporary solution while pagination is not 100%: disable pagination by default
-  $paginationSetting.prop('checked', false);
-
-  // /* from URL param */
-  // var enablePageBreaks = (getParam("pagebreak") !== "false"); // enable pagination by default
-  // if (enablePageBreaks) {
-  //   $paginationSetting.prop('checked', 'checked');
-  // } else {
-  //   $paginationSetting.prop('checked', false);
-  // }
-
-  // /* from cookie */
-  // if (padcookie.getPref(COOKIE_PREF_NAME)) {
-  //   $paginationSetting.prop('checked', 'checked');
-  // } else if (padcookie.getPref(COOKIE_PREF_NAME) == false) {
-  //   // only disable pagination if cookie is set to disabled it. If cookie is not set, we do nothing
-  //   $paginationSetting.prop("checked", false);
-  // }
-
-  // enable/disable pagination according to values read
-  if($paginationSetting.is(':checked')) {
-    automaticPagination.enable();
+var loadPageBreakInitialSettingFromURL = function() {
+  var urlParams = new URLSearchParams(window.location.search);
+  var paginationEnabled = urlParams.get('pagebreak');
+  if (paginationEnabled) {
+    enablePagination();
   } else {
-    automaticPagination.disable();
+    disablePagination();
   }
-}
-
-function getParam(sname) {
-  var params = location.search.substr(location.search.indexOf("?")+1);
-  var sval = "";
-  params = params.split("&");
-  // split param and value into individual pieces
-  for (var i=0; i<params.length; i++)
-  {
-    temp = params[i].split("=");
-    if ( [temp[0]] == sname ) { sval = temp[1]; }
-  }
-  return sval;
 }

--- a/static/js/lineMergingOnKeyEvent.js
+++ b/static/js/lineMergingOnKeyEvent.js
@@ -23,7 +23,7 @@ exports.aceKeyEvent = function(hook, context) {
 
 var getMergeInfo = function(editorInfo, attributeManager, evt, rep) {
   // check key pressed before anything else to be more efficient
-  var isMergeKey = (evt.keyCode === BACKSPACE || evt.keyCode === DELETE) && evt.type === "keydown";
+  var isMergeKey = (evt.keyCode === BACKSPACE || evt.keyCode === DELETE) && evt.type === 'keydown';
 
   // if text is selected, we simply ignore, as it is not a merge event
   if (isMergeKey && !textSelected(editorInfo)) {

--- a/static/js/pagination.js
+++ b/static/js/pagination.js
@@ -1,7 +1,7 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 
-var scriptElementUtils = require("ep_script_elements/static/js/utils");
+var scriptElementUtils = require('ep_script_elements/static/js/utils');
 
 var utils                      = require('./utils');
 var paginationSplit            = require('./paginationSplit');
@@ -15,10 +15,10 @@ var paginationCalculation      = require('./paginationPageBreaksCalculation');
 var paginationLineObserver     = require('./paginationLineObserver');
 var cssOptimization            = require('./cssOptimization');
 
-var isInTheMiddleOfASceneMarkVisibilityToggle = require("ep_script_scene_marks/static/js/sceneMarkVisibility").isInTheMiddleOfASceneMarkVisibilityToggle;
+var isInTheMiddleOfASceneMarkVisibilityToggle = require('ep_script_scene_marks/static/js/sceneMarkVisibility').isInTheMiddleOfASceneMarkVisibilityToggle;
 
-var PAGE_BREAK = paginationNonSplit.PAGE_BREAK_TAG + "," + paginationSplit.PAGE_BREAK_TAG;
-var DIV_WITH_PAGE_BREAK = "div:has(" + PAGE_BREAK + ")";
+var PAGE_BREAK = paginationNonSplit.PAGE_BREAK_TAG + ',' + paginationSplit.PAGE_BREAK_TAG;
+var DIV_WITH_PAGE_BREAK = 'div:has(' + PAGE_BREAK + ')';
 
 var REPAGINATION_LINE_SHIFT = 3;
 var REACHED_END_OF_PAD = -1;
@@ -78,11 +78,11 @@ exports.aceAttribsToClasses = function(hook, context) {
 }
 
 exports.aceDomLineProcessLineAttributes = function(hook, context) {
-  var scrollTargetHtml = paginationScrollPosition.buildHtmlWithTargetScroll(context.cls) || "";
+  var scrollTargetHtml = paginationScrollPosition.buildHtmlWithTargetScroll(context.cls) || '';
   var pageBreak = paginationNonSplit.buildHtmlWithPageBreaks(context.cls) ||
                   paginationSplit.buildHtmlWithPageBreaks(context.cls) ||
                   // use a default object for clearer code bellow
-                  { preHtml: "", postHtml: "", default: true };
+                  { preHtml: '', postHtml: '', default: true };
 
   if (scrollTargetHtml || !pageBreak.default) {
     var modifier = {
@@ -106,15 +106,15 @@ exports.acePostWriteDomLineHTML = function(hook, context) {
 
   // adjust layout of parentheticals split between pages
   if (nodeHasSplitPageBreak) {
-    $node.addClass("firstHalf");
+    $node.addClass('firstHalf');
   }
 
   // leave room for page break on line at the end of the page
   if (nodeHasSplitPageBreak || nodeHasNonSplitPageBreak) {
-    $node.addClass("beforePageBreak");
+    $node.addClass('beforePageBreak');
   }
   if (nodeHasMoreAndContd) {
-    $node.addClass("withMoreAndContd");
+    $node.addClass('withMoreAndContd');
   }
 }
 
@@ -123,7 +123,7 @@ exports.aceEditEvent = function(hook, context) {
   var eventType = callstack.type;
 
   // if page break is disabled, only remove possible existing page breaks, don't do anything else
-  var pageBreakIsDisabled = !clientVars.plugins.plugins.ep_script_page_view.pageBreakEnabled;
+  var pageBreakIsDisabled = !utils.getPluginProps().pageBreakEnabled;
   if (pageBreakIsDisabled) {
     if (finishedLoadingPad(eventType)) {
       cleanAllPageBreaks(context);
@@ -188,7 +188,7 @@ var scriptHasNoPaginationYet = function() {
 }
 
 var isEditedByMe = function(eventType) {
-  return eventType !== "applyChangesToBase";
+  return eventType !== 'applyChangesToBase';
 }
 
 var paginationDidNotFinish = function() {
@@ -198,17 +198,17 @@ var isAChangeOnElementType = function(eventType) {
   return eventType === scriptElementUtils.CHANGE_ELEMENT_EVENT;
 }
 var isAPaginationScheduledByMe = function(eventType) {
-  return eventType === "pagination-" + clientVars.userId;
+  return eventType === 'pagination-' + clientVars.userId;
 }
 
 var myPaginationEventType = function() {
-  return "pagination-" + clientVars.userId;
+  return 'pagination-' + clientVars.userId;
 }
 
 var paginationTimer;
 var resetTimerToRestartPagination = function(context) {
   // define delay if not defined yet
-  clientVars.plugins.plugins.ep_script_page_view.paginationDelay = clientVars.plugins.plugins.ep_script_page_view.paginationDelay || 500;
+  utils.getPluginProps().paginationDelay = utils.getPluginProps().paginationDelay || 500;
 
   var editorInfo = context.editorInfo;
 
@@ -219,7 +219,7 @@ var resetTimerToRestartPagination = function(context) {
     editorInfo.ace_callWithAce(function(ace) {
       // do nothing here, we handle pagination on aceEditEvent
     }, myPaginationEventType());
-  }, clientVars.plugins.plugins.ep_script_page_view.paginationDelay);
+  }, utils.getPluginProps().paginationDelay);
 }
 
 // simpler version of repaginate(), should be run only on clean pads (with no pagination)

--- a/static/js/paginationBlocks.js
+++ b/static/js/paginationBlocks.js
@@ -16,8 +16,8 @@ exports.getBlockInfo = function($helperLine) {
   // block type:
   // (*) => transition (only one line of text)
   //        +--------- $currentLine ----------+
-  if (typeOfCurrentLine === "transition" && innerLinesOfCurrentLine === 1) {
-    if (typeOfPreviousLine !== "parenthetical" && typeOfPreviousLine !== "dialogue" ) {
+  if (typeOfCurrentLine === 'transition' && innerLinesOfCurrentLine === 1) {
+    if (typeOfPreviousLine !== 'parenthetical' && typeOfPreviousLine !== 'dialogue' ) {
       $topOfBlock = $previousLine;
     }
     // block type:
@@ -34,14 +34,14 @@ exports.getBlockInfo = function($helperLine) {
       $topOfBlock = $previousLine;
     }
   }
-  else if (typeOfCurrentLine === "parenthetical" || typeOfCurrentLine === "dialogue") {
-    if (typeOfPreviousLine === "character") {
+  else if (typeOfCurrentLine === 'parenthetical' || typeOfCurrentLine === 'dialogue') {
+    if (typeOfPreviousLine === 'character') {
       var $lineBeforePrevious = $previousLine.prev();
       var typeOfLineBeforePrevious = utils.typeOf($lineBeforePrevious);
       // block type:
       // heading => character => (parenthetical || dialogue)
       //                         +------ $currentLine -----+
-      if (typeOfLineBeforePrevious === "heading") {
+      if (typeOfLineBeforePrevious === 'heading') {
         $topOfBlock = $lineBeforePrevious;
       }
       // block type:
@@ -51,14 +51,14 @@ exports.getBlockInfo = function($helperLine) {
         $topOfBlock = $previousLine;
       }
     }
-    else if (typeOfPreviousLine === "parenthetical" || typeOfPreviousLine === "dialogue") {
+    else if (typeOfPreviousLine === 'parenthetical' || typeOfPreviousLine === 'dialogue') {
       // block type:
       // !character => (parenthetical || dialogue) => (parenthetical || dialogue) (only one line of text) => !(parenthetical || dialogue)
       //                                              +------------------ $currentLine -----------------+
       if (innerLinesOfCurrentLine === 1) {
         var $lineBeforePrevious = $previousLine.prev();
         var typeOfLineBeforePrevious = utils.typeOf($lineBeforePrevious);
-        if (typeOfLineBeforePrevious !== "character" && typeOfNextLine !== "dialogue" && typeOfNextLine !== "parenthetical") {
+        if (typeOfLineBeforePrevious !== 'character' && typeOfNextLine !== 'dialogue' && typeOfNextLine !== 'parenthetical') {
           $topOfBlock = $previousLine;
         }
       }
@@ -68,7 +68,7 @@ exports.getBlockInfo = function($helperLine) {
       else if (getNumberOfInnerLinesOf($previousLine) === 1) {
         var $lineBeforePrevious = $previousLine.prev();
         var typeOfLineBeforePrevious = utils.typeOf($lineBeforePrevious);
-        if (typeOfLineBeforePrevious === "character") {
+        if (typeOfLineBeforePrevious === 'character') {
           $topOfBlock = $lineBeforePrevious;
         }
       }
@@ -76,15 +76,15 @@ exports.getBlockInfo = function($helperLine) {
     // block type:
     // !(character) => (parenthetical || dialogue) (only one line of text) => !(parenthetical || dialogue)
     //                 +------------------ $currentLine -----------------+
-    else if ((typeOfNextLine !== "parenthetical" && typeOfNextLine !== "dialogue")
+    else if ((typeOfNextLine !== 'parenthetical' && typeOfNextLine !== 'dialogue')
       &&
       innerLinesOfCurrentLine === 1) {
       $topOfBlock = $previousLine;
     }
   }
-  else if ((typeOfCurrentLine === "parenthetical" || typeOfCurrentLine === "dialogue")
+  else if ((typeOfCurrentLine === 'parenthetical' || typeOfCurrentLine === 'dialogue')
     &&
-    (typeOfNextLine !== "parenthetical" && typeOfNextLine !== "dialogue")
+    (typeOfNextLine !== 'parenthetical' && typeOfNextLine !== 'dialogue')
     &&
     innerLinesOfCurrentLine === 1) {
     $topOfBlock = $previousLine;
@@ -92,9 +92,9 @@ exports.getBlockInfo = function($helperLine) {
   // block type:
   // (heading || shot) => (action || character || general)
   //                      +-------- $currentLine --------+
-  else if ((typeOfCurrentLine === "action" || typeOfCurrentLine === "character" || typeOfCurrentLine === "general")
+  else if ((typeOfCurrentLine === 'action' || typeOfCurrentLine === 'character' || typeOfCurrentLine === 'general')
     &&
-    (typeOfPreviousLine === "heading" || typeOfPreviousLine === "shot")) {
+    (typeOfPreviousLine === 'heading' || typeOfPreviousLine === 'shot')) {
     $topOfBlock = $previousLine;
   }
 

--- a/static/js/paginationLineObserver.js
+++ b/static/js/paginationLineObserver.js
@@ -1,7 +1,7 @@
 var utils = require('./utils');
 var paginationLinesChanged = require('./paginationLinesChanged');
 
-var sceneMarkUtils = require("ep_script_scene_marks/static/js/utils");
+var sceneMarkUtils = require('ep_script_scene_marks/static/js/utils');
 
 exports.init = function() {
   startObserving();

--- a/static/js/paginationNonSplit.js
+++ b/static/js/paginationNonSplit.js
@@ -1,11 +1,11 @@
 var utils = require('./utils');
 var paginationPageNumber = require('./paginationPageNumber');
 
-var PAGE_BREAKS_ATTRIB                     = "nonSplitPageBreak";
-var PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB = "nonSplitPageBreakWithMoreAndContd";
+var PAGE_BREAKS_ATTRIB                     = 'nonSplitPageBreak';
+var PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB = 'nonSplitPageBreakWithMoreAndContd';
 exports.PAGE_BREAK_ATTRIBS = [PAGE_BREAKS_ATTRIB, PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB];
 
-var PAGE_BREAK_TAG = "nonSplitPageBreak";
+var PAGE_BREAK_TAG = 'nonSplitPageBreak';
 exports.PAGE_BREAK_TAG = PAGE_BREAK_TAG;
 utils.registerPageBreakTag(PAGE_BREAK_TAG);
 
@@ -113,8 +113,8 @@ var callAllListenersOfHeadingOnTopOfPage = function(headingLineNumber, attribute
 }
 
 var getMoreAndContdInfo = function($line) {
-  var lineIsParentheticalOrDialogue = $line.has("parenthetical, dialogue").length > 0;
-  var nextLineIsParentheticalOrDialogue = $line.next().has("parenthetical, dialogue").length > 0;
+  var lineIsParentheticalOrDialogue = $line.has('parenthetical, dialogue').length > 0;
+  var nextLineIsParentheticalOrDialogue = $line.next().has('parenthetical, dialogue').length > 0;
 
   if (lineIsParentheticalOrDialogue && nextLineIsParentheticalOrDialogue) {
     return {

--- a/static/js/paginationPageBreaksCalculation.js
+++ b/static/js/paginationPageBreaksCalculation.js
@@ -5,8 +5,8 @@ var paginationBlocks           = require('./paginationBlocks');
 var paginationSplit            = require('./paginationSplit');
 var paginationNonSplit         = require('./paginationNonSplit');
 
-var PAGE_BREAK = paginationNonSplit.PAGE_BREAK_TAG + "," + paginationSplit.PAGE_BREAK_TAG;
-var DIV_WITH_PAGE_BREAK = "div:has(" + PAGE_BREAK + ")";
+var PAGE_BREAK = paginationNonSplit.PAGE_BREAK_TAG + ',' + paginationSplit.PAGE_BREAK_TAG;
+var DIV_WITH_PAGE_BREAK = 'div:has(' + PAGE_BREAK + ')';
 
 var MAX_PAGE_BREAKS_PER_CYCLE = 5;
 var PAGE_BREAK_HEIGHT = 16;
@@ -21,7 +21,7 @@ exports.calculatePageBreaks = function(startLine, originalCaretPosition, attribu
   var pageBreaks = [];
 
   // start paginating only from startLine
-  var $linesOfScript = utils.getPadInner().find("div");
+  var $linesOfScript = utils.getPadInner().find('div');
   var $firstLineAfterLastUnchangedPageBreak = lineAfterUnchangedPageBreak(startLine, $linesOfScript, rep);
 
   var $helperLines = createHelperLines($firstLineAfterLastUnchangedPageBreak, $linesOfScript);
@@ -121,17 +121,17 @@ var increaseOffsetTop = function(offset, topShift) {
 
 var getNumberOfMergedLinesOnPage = function(pageBreakInfo) {
   var $linesOfThisPage = pageBreakInfo.$firstLineOfThisPage.nextUntil(pageBreakInfo.$firstLineOfNextPage).andSelf();
-  var $mergedLinesOfThisPage = $linesOfThisPage.filter("." + paginationSplit.MERGED_LINE);
+  var $mergedLinesOfThisPage = $linesOfThisPage.filter('.' + paginationSplit.MERGED_LINE);
   return $mergedLinesOfThisPage.length;
 }
 
 var adjustPadInnerHeight = function() {
   var padInnerFrame = utils.getPadOuter().find("iframe[name='ace_inner']");
-  var originalHeight = parseInt(padInnerFrame.css("height"));
+  var originalHeight = parseInt(padInnerFrame.css('height'));
 
   // change pad inner css to force pad outer to adjust
   var heightWithHelperLines = utils.getPadInner().height();
-  padInnerFrame.css("height", heightWithHelperLines.toString() + "px");
+  padInnerFrame.css('height', heightWithHelperLines.toString() + 'px');
 
   return originalHeight;
 }
@@ -165,18 +165,18 @@ var getFirstLineNotReachedByThisPaginationCycle = function(startAtOffset) {
 var getLineAt = function(offset) {
   var editorDocument  = utils.getPadOuter().find("iframe[name='ace_inner']").get(0).contentDocument;
   var elementAtOffset = editorDocument.elementFromPoint(offset.left, offset.top);
-  var $lineAtOffset = $(elementAtOffset).closest("div");
+  var $lineAtOffset = $(elementAtOffset).closest('div');
 
   // offset might be at a margin, so try next line
   if ($lineAtOffset.length === 0) {
     var oneLine = utils.getHeightOfOneLine();
     elementAtOffset = editorDocument.elementFromPoint(offset.left, offset.top + oneLine);
-    $lineAtOffset = $(elementAtOffset).closest("div");
+    $lineAtOffset = $(elementAtOffset).closest('div');
 
     // headings have 2-lines margin, so it's possible that we still didn't reach its content
     if ($lineAtOffset.length === 0) {
       elementAtOffset = editorDocument.elementFromPoint(offset.left, offset.top + 2*oneLine);
-      $lineAtOffset = $(elementAtOffset).closest("div");
+      $lineAtOffset = $(elementAtOffset).closest('div');
     }
   }
 
@@ -228,8 +228,8 @@ var getTotalHeightOfPaginationCycle = function() {
 }
 
 var getOriginalLineFromHelperLine = function($helperLine, $linesOfScript) {
-  var lineId = $helperLine.attr("data-original-id");
-  var $originalLine = $linesOfScript.filter("#"+lineId);
+  var lineId = $helperLine.attr('data-original-id');
+  var $originalLine = $linesOfScript.filter('#'+lineId);
 
   return $originalLine;
 }

--- a/static/js/paginationPageNumber.js
+++ b/static/js/paginationPageNumber.js
@@ -1,6 +1,6 @@
 var utils = require('./utils');
 
-var PAGE_NUMBER_ATTRIB = "pageNumber";
+var PAGE_NUMBER_ATTRIB = 'pageNumber';
 exports.PAGE_NUMBER_ATTRIB = PAGE_NUMBER_ATTRIB;
 
 exports.cleanPageBreaks = function(startAtLine, endAtLine, attributeManager) {

--- a/static/js/paginationScrollPosition.js
+++ b/static/js/paginationScrollPosition.js
@@ -3,23 +3,23 @@ var _ = require('ep_etherpad-lite/static/js/underscore');
 
 var utils = require('./utils');
 
-var SCROLL_SHIFT_ATTRIB = "scroll_shift";
-var SORT_ORDER_ATTRIB   = "sort_order";
+var SCROLL_SHIFT_ATTRIB = 'scroll_shift';
+var SORT_ORDER_ATTRIB   = 'sort_order';
 
 var SCROLL_SHIFT_REGEXP = new RegExp("(?:^|)" + SCROLL_SHIFT_ATTRIB + ":(\\S+)");
 var SORT_ORDER_REGEXP   = new RegExp("(?:^|)" + SORT_ORDER_ATTRIB + ":([0-9]+)");
 
-var SCROLL_TARGET_TAG = "scroll_target";
+var SCROLL_TARGET_TAG = 'scroll_target';
 
-var MAIN_TARGET = "1";
-var NEXT_TARGET = "2";
-var PREV_TARGET = "3";
+var MAIN_TARGET = '1';
+var NEXT_TARGET = '2';
+var PREV_TARGET = '3';
 
 exports.buildHtmlWithTargetScroll = function(cls) {
-  var scrollTarget = getShiftValueFromClass(cls) || "";
+  var scrollTarget = getShiftValueFromClass(cls) || '';
 
   if(scrollTarget) {
-    var sortOrder = getSortOrderValueFromClass(cls) || "";
+    var sortOrder = getSortOrderValueFromClass(cls) || '';
 
     var shiftAttrib     = " " + SCROLL_SHIFT_ATTRIB + "='" + scrollTarget + "'";
     var sortOrderAttrib = " " + SORT_ORDER_ATTRIB   + "='" + sortOrder    + "'";
@@ -45,7 +45,7 @@ exports.blockElements = function() {
 
 exports.atribsToClasses = function(context) {
   if (isScrollTarget(context.key) || isSortOrder(context.key)) {
-    return [context.key + ":" + context.value];
+    return [context.key + ':' + context.value];
   }
 }
 var isScrollTarget = function(contextKey) {
@@ -107,7 +107,7 @@ var getCaretLineOnViewport = function(viewportScrollTop, rep) {
   var caretLineNode = utils.getDOMLineFromLineNumber(caretLine, rep);
 
   if (lineIsOnViewport(caretLineNode, viewportScrollTop)) {
-    return utils.getPadInner().find("#" + caretLineNode.id).first();
+    return utils.getPadInner().find('#' + caretLineNode.id).first();
   }
 }
 
@@ -123,7 +123,7 @@ var lineIsOnViewport = function(lineNode, viewportScrollTop) {
 }
 
 var getFirstLineVisibleOnViewport = function(viewportScrollTop) {
-  var $lines = utils.getPadInner().find("div");
+  var $lines = utils.getPadInner().find('div');
   var found = false;
   var $linesAfterViewportTop = $lines.filter(function() {
     if (!found && this.getBoundingClientRect().top >= viewportScrollTop) {
@@ -164,7 +164,7 @@ var adjustScrollToMatchAnchorLine = function(attributeManager, rep) {
 }
 
 var getAnchorLines = function() {
-  var $anchorLines = utils.getPadInner().find("div:has(" + SCROLL_TARGET_TAG + ")");
+  var $anchorLines = utils.getPadInner().find('div:has(' + SCROLL_TARGET_TAG + ')');
   // return line sorted, so we use the one with highest priority (lowest SORT_ORDER_ATTRIB value)
   var $sortedAnchorLines = $anchorLines.sort(function(prev, next) {
     var prevSortOrder = parseInt(sortOrderOf($(prev)));
@@ -180,7 +180,7 @@ var sortOrderOf = function($line) {
 }
 
 var pageBreakHeightOf = function($line) {
-  return parseInt($line.css("padding-bottom"));
+  return parseInt($line.css('padding-bottom'));
 }
 
 var removeMarksFromAnchorLines = function($lines, attributeManager, rep) {

--- a/static/js/paginationSplit.js
+++ b/static/js/paginationSplit.js
@@ -6,11 +6,11 @@ var paginationPageNumber = require('./paginationPageNumber');
 var paginationNonSplit   = require('./paginationNonSplit');
 var scriptElementUtils   = require('ep_script_elements/static/js/utils');
 
-var PAGE_BREAKS_ATTRIB                     = "splitPageBreak";
-var PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB = "splitPageBreakWithMoreAndContd";
+var PAGE_BREAKS_ATTRIB                     = 'splitPageBreak';
+var PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB = 'splitPageBreakWithMoreAndContd';
 
-var FIRST_HALF_ATTRIB = "splitFirstHalf";
-var SECOND_HALF_ATTRIB = "splitSecondHalf";
+var FIRST_HALF_ATTRIB = 'splitFirstHalf';
+var SECOND_HALF_ATTRIB = 'splitSecondHalf';
 
 var ETHERPAD_AND_PAGE_BREAK_ATTRIBS = _.union(
   [
@@ -25,13 +25,13 @@ var ETHERPAD_AND_PAGE_BREAK_ATTRIBS = _.union(
   paginationNonSplit.PAGE_BREAK_ATTRIBS
 );
 
-var PAGE_BREAK_TAG = "splitPageBreak";
+var PAGE_BREAK_TAG = 'splitPageBreak';
 exports.PAGE_BREAK_TAG = PAGE_BREAK_TAG;
 utils.registerPageBreakTag(PAGE_BREAK_TAG);
 
-var FIRST_HALF_TAG                     = "split_first_half";
-var FIRST_HALF_WITH_MORE_AND_CONTD_TAG = "split_with_more_and_contd_first_half";
-var SECOND_HALF_TAG                    = "split_second_half";
+var FIRST_HALF_TAG                     = 'split_first_half';
+var FIRST_HALF_WITH_MORE_AND_CONTD_TAG = 'split_with_more_and_contd_first_half';
+var SECOND_HALF_TAG                    = 'split_second_half';
 exports.SECOND_HALF_TAG = SECOND_HALF_TAG;
 
 var DO_NOT_COLLECT = 'ignore_pagination_attribs';
@@ -39,7 +39,7 @@ var DO_NOT_COLLECT = 'ignore_pagination_attribs';
 var SENTENCE_MARKER_AND_WHITESPACE_REGEX = /^(.*[.?!;]\s+)[^.?!;]*$/;
 var WHITESPACE_REGEX                     = /^(.*\s+)[^\s]*$/;
 
-var MERGED_LINE = "merged";
+var MERGED_LINE = 'merged';
 exports.MERGED_LINE = MERGED_LINE;
 
 // number of minimum lines each element needs before a page break so it can be split in two parts
@@ -109,7 +109,7 @@ exports.getSplitInfo = function($helperLine, $originalLine, lineNumberShift, ava
 // Put together information about the line. Use the returned value to move around line information
 // through the functions of this file
 var getLineInfo = function($helperLine, $originalLine, originalCaretPosition, attributeManager, rep) {
-  var lineIdBeforeRepagination     = $originalLine.attr("id");
+  var lineIdBeforeRepagination     = $originalLine.attr('id');
   var lineNumberBeforeRepagination = rep.lines.indexOfKey(lineIdBeforeRepagination);
   var lineHasMarker                = lineHasMarkerExcludingSplitLineMarkers(lineNumberBeforeRepagination, attributeManager);
   // If line has no marker, it means it lost its "*", so we need to decrement column number
@@ -171,9 +171,9 @@ var getMinimumLinesBeforePageBreakFor = function(lineInfo) {
 
   // exception: if current line is a dialogue or parenthetical, and previous line is a character,
   // it needs 2 lines before page break, and not only 1
-  if (typeOfLine === "dialogue" || typeOfLine === "parenthetical") {
+  if (typeOfLine === 'dialogue' || typeOfLine === 'parenthetical') {
     var typeOfPreviousLine = lineInfo.typeOfPreviousLine();
-    if (typeOfPreviousLine === "character") {
+    if (typeOfPreviousLine === 'character') {
       minimumLines = 2;
     }
   }
@@ -189,7 +189,7 @@ var getMinimumLinesAfterPageBreakFor = function(lineInfo) {
 
 var getSplitMethod = function(lineInfo) {
   var typeOfLine = lineInfo.typeOfLine;
-  if (typeOfLine === "general" || typeOfLine === "transition") {
+  if (typeOfLine === 'general' || typeOfLine === 'transition') {
     return getFirstCharAfterLastSentenceMarkerAndWhitespacesOrFullInnerLine;
   }
   return getFirstCharAfterLastSentenceMarkerAndWhitespacesOfInnerLine;
@@ -329,7 +329,7 @@ var calculateHeightToFitText = function(text, lineInfo) {
   var $theClone = utils.createCleanCopyOf($originalLine, text);
 
   // parentheticals need this to calculate line height without any "()"
-  $theClone.addClass("clone");
+  $theClone.addClass('clone');
 
   var height = $theClone.insertAfter($originalLine).get(0).getBoundingClientRect().height;
   $theClone.remove();
@@ -381,7 +381,7 @@ exports.collectContentPre = function(hook, context) {
   if (shouldNotCollectThisTag) return;
 
   // new line
-  if (tname === "div") {
+  if (tname === 'div') {
     delete lineAttributes[PAGE_BREAKS_ATTRIB];
     delete lineAttributes[PAGE_BREAKS_WITH_MORE_AND_CONTD_ATTRIB];
     delete lineAttributes[FIRST_HALF_ATTRIB];
@@ -449,7 +449,7 @@ var getSplitIdFromClass = function(cls) {
 }
 
 var newSplitId = function() {
-  return "split-" + randomString(16);
+  return 'split-' + randomString(16);
 }
 
 exports.blockElements = function() {
@@ -510,7 +510,7 @@ exports.mergeLinesWithExtraChars = function(lineNumber, rep, attributeManager, e
     var end = [lineNumber+1, charsToRemoveOnSecondHalf];
 
     // remove "\n" at the end of the line
-    editorInfo.ace_replaceRange(start, end, "");
+    editorInfo.ace_replaceRange(start, end, '');
   }
 }
 
@@ -604,8 +604,8 @@ var linesAreHalvesOfSameSplit = function($targetLine, $nextLine) {
 
   var lineIsFirstHalfOfSplit = $targetLine.find(PAGE_BREAK_TAG).length > 0;
   if (lineIsFirstHalfOfSplit) {
-    var firstHalfClass  = $targetLine.find(FIRST_HALF_TAG + "," + FIRST_HALF_WITH_MORE_AND_CONTD_TAG).attr("class");
-    var secondHalfClass = $nextLine.find(SECOND_HALF_TAG).attr("class");
+    var firstHalfClass  = $targetLine.find(FIRST_HALF_TAG + ',' + FIRST_HALF_WITH_MORE_AND_CONTD_TAG).attr('class');
+    var secondHalfClass = $nextLine.find(SECOND_HALF_TAG).attr('class');
     var splitIdOfFirstHalf  = getSplitIdFromClass(firstHalfClass);
     var splitIdOfSecondHalf = getSplitIdFromClass(secondHalfClass);
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -4,12 +4,12 @@ var Security = require('ep_etherpad-lite/static/js/security');
 
 var scriptElementUtils = require('ep_script_elements/static/js/utils');
 
-var EMPTY_CHARACTER_NAME = "empty";
+var EMPTY_CHARACTER_NAME = 'empty';
 
-var SCRIPT_ELEMENTS_SELECTOR = "heading, action, character, parenthetical, dialogue, transition, shot";
+var SCRIPT_ELEMENTS_SELECTOR = 'heading, action, character, parenthetical, dialogue, transition, shot';
 
-var CLONED_ELEMENTS_CLASS = "cloned";
-var CLONED_ELEMENTS_SELECTOR = "." + CLONED_ELEMENTS_CLASS;
+var CLONED_ELEMENTS_CLASS = 'cloned';
+var CLONED_ELEMENTS_SELECTOR = '.' + CLONED_ELEMENTS_CLASS;
 
 // Letter
 // var REGULAR_LINES_PER_PAGE = 54;
@@ -50,9 +50,13 @@ exports.getPadInner = function() {
 }
 var getPadInner = exports.getPadInner;
 
+exports.getPluginProps = function() {
+  return clientVars.plugins.plugins.ep_script_page_view;
+}
+
 exports.typeOf = function($line) {
   var $innerElement = $line.find(SCRIPT_ELEMENTS_SELECTOR);
-  var tagName = $innerElement.prop("tagName") || "general"; // general does not have inner tag
+  var tagName = $innerElement.prop('tagName') || 'general'; // general does not have inner tag
 
   return tagName.toLowerCase();
 }
@@ -133,11 +137,11 @@ exports.updateRegularLineHeight = function() {
 }
 
 exports.getWidthOfOneChar = function() {
-  return widthOf(getPadOuter().find("#linemetricsdiv"));
+  return widthOf(getPadOuter().find('#linemetricsdiv'));
 }
 
 exports.getHeightOfOneLine = function() {
-  return heightOf(getPadOuter().find("#linemetricsdiv"));
+  return heightOf(getPadOuter().find('#linemetricsdiv'));
 }
 var getHeightOfOneLine = exports.getHeightOfOneLine;
 
@@ -145,13 +149,13 @@ exports.findCharacterNameOf = function($line) {
   // navigate up until find an element that is not a dialogue or parenthetical
   // (include $line because there might be no dialogue or parenthetical before it, so the result would
   // be empty)
-  var $firstElementOfDialogueOfBlock = $line.prevUntil("div:not(:has(dialogue,parenthetical))").andSelf().first();
+  var $firstElementOfDialogueOfBlock = $line.prevUntil('div:not(:has(dialogue,parenthetical))').andSelf().first();
 
-  // element before dialogue block should be a character -- if it is not, the text will be ""
-  var $characterBeforeDialogueBlock = $firstElementOfDialogueOfBlock.prev().find("character");
+  // element before dialogue block should be a character -- if it is not, the text will be ''
+  var $characterBeforeDialogueBlock = $firstElementOfDialogueOfBlock.prev().find('character');
 
-  // we cannot store "" as character name, Etherpad considers this an inexistent attribute. So we
-  // store a fake value and replace it by "" when showing on editor
+  // we cannot store '' as character name, Etherpad considers this an inexistent attribute. So we
+  // store a fake value and replace it by '' when showing on editor
   var characterName = $characterBeforeDialogueBlock.text().toUpperCase() || EMPTY_CHARACTER_NAME;
 
   return characterName;
@@ -160,15 +164,15 @@ exports.findCharacterNameOf = function($line) {
 exports.performNonUnduableEvent = function(callstack, action) {
   var eventType = callstack.editEvent.eventType;
 
-  callstack.startNewEvent("nonundoable");
+  callstack.startNewEvent('nonundoable');
   action();
   callstack.startNewEvent(eventType);
 }
 
 exports.buildCharacterNameToClass = function(value) {
-  var characterName = (value === EMPTY_CHARACTER_NAME ? "" : value);
+  var characterName = (value === EMPTY_CHARACTER_NAME ? '' : value);
 
-  // "characterName:<character name>"
+  // 'characterName:<character name>'
   return 'characterName:<' + Security.escapeHTMLAttribute(characterName) + '>';
 }
 
@@ -195,13 +199,13 @@ var buildSimplePageBreak = exports.buildSimplePageBreak;
 var extractCharacterNameFromClass = function(cls) {
   var regex  = "(?:^| )characterName:<([^>]*)>"; // "characterName:<character name>"
   var characterNameFound = cls.match(new RegExp(regex));
-  var characterName = characterNameFound ? characterNameFound[1] : "";
+  var characterName = characterNameFound ? characterNameFound[1] : '';
 
   return characterName;
 }
 
 exports.pageNumberOfDOMLine = function($line) {
-  return $line.find("pagenumber").attr("data-page-number");
+  return $line.find('pagenumber').attr('data-page-number');
 }
 
 exports.buildPageNumberToClass = function(value) {
@@ -211,13 +215,13 @@ exports.buildPageNumberToClass = function(value) {
 var extractPageNumberFromClass = function(cls) {
   var regex = "(?:^| )pageNumber:([0-9]*)";
   var pageNumberFound = cls.match(new RegExp(regex));
-  var pageNumber = pageNumberFound ? pageNumberFound[1] : "";
+  var pageNumber = pageNumberFound ? pageNumberFound[1] : '';
 
   return pageNumber;
 }
 
 exports.getLineNumberFromDOMLine = function($line, rep) {
-  var lineId     = $line.attr("id");
+  var lineId     = $line.attr('id');
   var lineNumber = rep.lines.indexOfKey(lineId);
 
   return lineNumber;
@@ -236,7 +240,7 @@ exports.getNextLineIgnoringSceneMarks = function($targetLine) {
 }
 
 exports.nodeHasMoreAndContd = function($node) {
-  return $node.find("more").length > 0;
+  return $node.find('more').length > 0;
 }
 
 exports.setTextOfLine = function($targetLine, text) {
@@ -265,10 +269,10 @@ exports.createCleanCopyOf = function($targetLine, text) {
     innerHtml = text;
   } else {
     var tag = $innerTarget.get(0).tagName.toLowerCase();
-    innerHtml = "<" + tag + ">" + text + "</" + tag + ">";
+    innerHtml = '<' + tag + '>' + text + '</' + tag + '>';
   }
 
-  return $("<div>" + innerHtml + "</div>");
+  return $('<div>' + innerHtml + '</div>');
 }
 
 exports.cleanHelperLines = function($helperLines) {
@@ -278,26 +282,26 @@ exports.cleanHelperLines = function($helperLines) {
   $helperLines.find(getPageBreakTagsSelector()).remove();
 
   // remove classes that impact element dimensions
-  $helperLines.removeClass("firstHalf beforePageBreak withMoreAndContd");
+  $helperLines.removeClass('firstHalf beforePageBreak withMoreAndContd');
 
   // store original id on another attribute so it can be retrieved later
   $helperLines.each(function(index, element) {
     var $helperLine = $(element);
-    var originalId = $helperLine.attr("id");
-    $helperLine.attr("data-original-id", originalId);
+    var originalId = $helperLine.attr('id');
+    $helperLine.attr('data-original-id', originalId);
 
     // remove id to not mess up with existing lines
-    $helperLine.attr("id", "");
+    $helperLine.attr('id', '');
   });
 }
 
-var pageBreakTags = ["more", "contdLine", "pagenumber"];
+var pageBreakTags = ['more', 'contdLine', 'pagenumber'];
 var pageBreakTagsSelector;
 exports.registerPageBreakTag = function(tagName) {
   pageBreakTags.push(tagName);
 
   // cache selector for faster processing
-  pageBreakTagsSelector = _(pageBreakTags).unique().join(",");
+  pageBreakTagsSelector = _(pageBreakTags).unique().join(',');
 }
 
 var getPageBreakTagsSelector = function() {

--- a/static/tests/frontend/specs/basicPagination.js
+++ b/static/tests/frontend/specs/basicPagination.js
@@ -18,7 +18,7 @@ var DIALOGUES_PER_PAGE      = 58;
 var TRANSITIONS_PER_PAGE    = 28;
 var SHOTS_PER_PAGE          = 20;
 
-describe.skip("ep_script_page_view - pagination basic tests", function() {
+describe.skip('ep_script_page_view - pagination basic tests', function() {
   var utils, pageBreak;
 
   var getPageBuilder = function(elementsPerPage, builder) {
@@ -33,20 +33,20 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
     this.timeout(60000);
   });
 
-  context("when lines do not have any top or bottom margin", function() {
+  context('when lines do not have any top or bottom margin', function() {
     before(function(done) {
       var scriptBuilder = pageBreak.scriptWithPageFullOfGenerals;
       pageBreak.createScript(scriptBuilder, done);
     });
 
-    it("fits " + GENERALS_PER_PAGE + " lines in a page", function(done) {
+    it('fits ' + GENERALS_PER_PAGE + ' lines in a page', function(done) {
       var elementBuilder = utils.general;
       var pageBuilder    = getPageBuilder(GENERALS_PER_PAGE, elementBuilder);
       pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
     });
 
-    context("and one of the lines has its type changed", function() {
-      it("updates pagination", function(done) {
+    context('and one of the lines has its type changed', function() {
+      it('updates pagination', function(done) {
         var smUtils = ep_script_scene_marks_test_helper.utils;
 
         // change second line to action, so all lines will be shifted down one position
@@ -58,17 +58,17 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
             var $secondPageBreak = $linesWithPageBreaks.last();
             var $lineAfterSecondPageBreak = $secondPageBreak.next();
 
-            return ($firstPageBreak.text() === "1st page") &&
-                   ($secondPageBreak.text() === "2nd page") &&
-                   ($lineAfterSecondPageBreak.text() === "1st of 3rd page");
+            return ($firstPageBreak.text() === '1st page') &&
+                   ($secondPageBreak.text() === '2nd page') &&
+                   ($lineAfterSecondPageBreak.text() === '1st of 3rd page');
           }, 3000).done(done);
         });
       });
     });
   });
 
-  context("when lines have top or bottom margin", function() {
-    context("and all lines are headings", function() {
+  context('when lines have top or bottom margin', function() {
+    context('and all lines are headings', function() {
       before(function(done) {
         var test = this;
         var scriptBuilder = getPageBuilder(HEADINGS_PER_PAGE, utils.heading);
@@ -79,7 +79,7 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
         });
       });
 
-      it("fits " + HEADINGS_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + HEADINGS_PER_PAGE + ' lines in a page', function(done) {
         pageBreak.checkIfItFitsXLinesPerPage(done);
       });
 
@@ -114,14 +114,14 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
       });
 
       // this is valid for some other elements too (but not for generals)
-      context("and last line is of page too long to fit entirely on it", function() {
+      context('and last line is of page too long to fit entirely on it', function() {
         var veryLongLineText;
 
         before(function() {
           var inner$ = helper.padInner$;
 
-          // "PAGE2.........(...). "
-          veryLongLineText = "PAGE2" + utils.buildStringWithLength(61 - "PAGE2".length, ".") + " ";
+          // 'PAGE2.........(...). '
+          veryLongLineText = 'PAGE2' + utils.buildStringWithLength(61 - 'PAGE2'.length, '.') + ' ';
 
           // removes all lines on last page, so we can easily access last line of last page
           var $lastLineOfSecondPage = utils.linesAfterNonSplitPageBreaks().last().prev();
@@ -130,12 +130,12 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
 
           // replaces last line with a very long text (> 61 chars, so it is
           // displayed in 2 lines on the editor)
-          var $lastLine = inner$("div").last().find("heading");
-          $lastLine.sendkeys("{selectall}");
+          var $lastLine = inner$('div').last().find('heading');
+          $lastLine.sendkeys('{selectall}');
           $lastLine.sendkeys(veryLongLineText);
         });
 
-        it("moves line to next page", function(done) {
+        it('moves line to next page', function(done) {
           var inner$ = helper.padInner$;
 
           // wait for new page to be created
@@ -155,78 +155,78 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
       });
     });
 
-    context("and all lines are actions", function() {
+    context('and all lines are actions', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(ACTIONS_PER_PAGE, utils.action);
         pageBreak.createScript(scriptBuilder, done);
       });
 
-      it("fits " + ACTIONS_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + ACTIONS_PER_PAGE + ' lines in a page', function(done) {
         var elementBuilder = utils.action;
         var pageBuilder    = getPageBuilder(ACTIONS_PER_PAGE, elementBuilder);
         pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
       });
     });
 
-    context("and all lines are characters", function() {
+    context('and all lines are characters', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(CHARACTERS_PER_PAGE, utils.character);
         pageBreak.createScript(scriptBuilder, done);
       });
 
-      it("fits " + CHARACTERS_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + CHARACTERS_PER_PAGE + ' lines in a page', function(done) {
         var elementBuilder = utils.character;
         var pageBuilder    = getPageBuilder(CHARACTERS_PER_PAGE, elementBuilder);
         pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
       });
     });
 
-    context("and all lines are parentheticals", function() {
+    context('and all lines are parentheticals', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(PARENTHETICALS_PER_PAGE, utils.parenthetical);
         pageBreak.createScript(scriptBuilder, done);
       });
 
-      it("fits " + PARENTHETICALS_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + PARENTHETICALS_PER_PAGE + ' lines in a page', function(done) {
         var elementBuilder = utils.parenthetical;
         var pageBuilder    = getPageBuilder(PARENTHETICALS_PER_PAGE, elementBuilder);
         pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
       });
     });
 
-    context("and all lines are dialogues", function() {
+    context('and all lines are dialogues', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(DIALOGUES_PER_PAGE, utils.dialogue);
         pageBreak.createScript(scriptBuilder, done);
       });
 
-      it("fits " + DIALOGUES_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + DIALOGUES_PER_PAGE + ' lines in a page', function(done) {
         var elementBuilder = utils.dialogue;
         var pageBuilder    = getPageBuilder(DIALOGUES_PER_PAGE, elementBuilder);
         pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
       });
     });
 
-    context("and all lines are transitions", function() {
+    context('and all lines are transitions', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(TRANSITIONS_PER_PAGE, utils.transition);
         pageBreak.createScript(scriptBuilder, done);
       });
 
-      it("fits " + TRANSITIONS_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + TRANSITIONS_PER_PAGE + ' lines in a page', function(done) {
         var elementBuilder = utils.transition;
         var pageBuilder    = getPageBuilder(TRANSITIONS_PER_PAGE, elementBuilder);
         pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
       });
     });
 
-    context("and all lines are shots", function() {
+    context('and all lines are shots', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(SHOTS_PER_PAGE, utils.shot);
         pageBreak.createScript(scriptBuilder, done);
       });
 
-      it("fits " + SHOTS_PER_PAGE + " lines in a page", function(done) {
+      it('fits ' + SHOTS_PER_PAGE + ' lines in a page', function(done) {
         var elementBuilder = utils.shot;
         var pageBuilder    = getPageBuilder(SHOTS_PER_PAGE, elementBuilder);
         pageBreak.testItFitsXLinesPerPage(elementBuilder, pageBuilder, this, done);
@@ -290,13 +290,13 @@ ep_script_page_view_test_helper.pageBreak = {
     expect($linesWithPageBreaks.length).to.be(0);
 
     // create another full page
-    var secondPage = pageBuilder("2nd page");
-    var $lastLine = inner$("div").last();
-    $lastLine.append("<br/>" + secondPage);
+    var secondPage = pageBuilder('2nd page');
+    var $lastLine = inner$('div').last();
+    $lastLine.append('<br/>' + secondPage);
 
     // add new line (should be placed on next page)
-    var $lastLine = inner$("div").last();
-    $lastLine.append(elementBuilder("1st of 3rd page") + elementBuilder("2nd of 3rd page"));
+    var $lastLine = inner$('div').last();
+    $lastLine.append(elementBuilder('1st of 3rd page') + elementBuilder('2nd of 3rd page'));
 
     // wait for new page to be created
     helper.waitFor(function() {

--- a/static/tests/frontend/specs/calculatingPageNumber.js
+++ b/static/tests/frontend/specs/calculatingPageNumber.js
@@ -1,4 +1,4 @@
-describe.skip("ep_script_page_view - calculating page number", function() {
+describe.skip('ep_script_page_view - calculating page number', function() {
   var utils;
 
   before(function(){
@@ -12,7 +12,7 @@ describe.skip("ep_script_page_view - calculating page number", function() {
     this.timeout(60000);
   });
 
-  context("when repagination is running and page number was not recalculated yet", function() {
+  context('when repagination is running and page number was not recalculated yet', function() {
     var MAX_PAGE_BREAKS_PER_CYCLE = 5;
 
     // build script with lots of pages, so repagination takes a while to finish
@@ -23,12 +23,12 @@ describe.skip("ep_script_page_view - calculating page number", function() {
 
       var inner$ = helper.padInner$;
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // each page has several single-line generals, and last line is a two-lines general
       // (so it is split later)
-      var line1 = utils.buildStringWithLength(50, "1") + ". ";
-      var line2 = utils.buildStringWithLength(50, "2") + ". ";
+      var line1 = utils.buildStringWithLength(50, '1') + '. ';
+      var line2 = utils.buildStringWithLength(50, '2') + '. ';
       var fullPage = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE - 2) +
                      utils.general(line1 + line2);
       var lastLine = utils.general(lastLineText);
@@ -41,8 +41,8 @@ describe.skip("ep_script_page_view - calculating page number", function() {
         }, 10000).done(function() {
           // inserts a long text to first line, so all lines will be shift one line down
           // and pagination will change scroll position of elements
-          var longText = utils.buildStringWithLength(62, "1");
-          var $firstLine = inner$("div").first();
+          var longText = utils.buildStringWithLength(62, '1');
+          var $firstLine = inner$('div').first();
           $firstLine.sendkeys(longText);
 
           // wait for first cycle of repagination to be completed before start testing
@@ -54,13 +54,13 @@ describe.skip("ep_script_page_view - calculating page number", function() {
       });
     });
 
-    it("displays a loading icon beside page number value", function(done) {
+    it('displays a loading icon beside page number value', function(done) {
       var inner$ = helper.padInner$;
 
-      var $pageNumbers = inner$("pagenumber");
+      var $pageNumbers = inner$('pagenumber');
       // <calculating> is 0x0 by default. When it has height and width, it means it's icon is being
       // displayed
-      var pageNumbersLoading = $pageNumbers.find("calculating:visible").length;
+      var pageNumbersLoading = $pageNumbers.find('calculating:visible').length;
       var expectedPageNumbersLoadingAfterFirstCycle = NUMBER_OF_PAGES - MAX_PAGE_BREAKS_PER_CYCLE;
 
       expect(pageNumbersLoading).to.be(expectedPageNumbersLoadingAfterFirstCycle);
@@ -68,7 +68,7 @@ describe.skip("ep_script_page_view - calculating page number", function() {
       done();
     });
 
-    context("and repagination is complete", function() {
+    context('and repagination is complete', function() {
 
       beforeEach(function(done) {
         this.timeout(10000);
@@ -80,11 +80,11 @@ describe.skip("ep_script_page_view - calculating page number", function() {
         }, 10000).done(done);
       });
 
-      it("does not display a loading icon beside page number value", function(done) {
+      it('does not display a loading icon beside page number value', function(done) {
         var inner$ = helper.padInner$;
 
-        var $pageNumbers = inner$("pagenumber");
-        var pageNumbersLoading = $pageNumbers.find("calculating:visible").length;
+        var $pageNumbers = inner$('pagenumber');
+        var pageNumbersLoading = $pageNumbers.find('calculating:visible').length;
 
         expect(pageNumbersLoading).to.be(0);
 

--- a/static/tests/frontend/specs/elementBlocks.js
+++ b/static/tests/frontend/specs/elementBlocks.js
@@ -3,7 +3,7 @@
 // A4
 var GENERALS_PER_PAGE = 58;
 
-describe.skip("ep_script_page_view - pagination of element blocks", function() {
+describe.skip('ep_script_page_view - pagination of element blocks', function() {
   var utils;
 
   var undoLastChanges = function(done) {
@@ -102,10 +102,10 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
       var seq         = utils.sequence('first sequence', 'summary of sequence');
       var synopsis    = utils.synopsis('first scene', 'summary of scene');
       var heading     = utils.heading('first heading');
-      var generals    = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE);
-      var lastGeneral = utils.general("last general");
+      var generals    = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE);
+      var lastGeneral = utils.general('last general');
       var script      = act + seq + synopsis + heading + generals + lastGeneral;
-      utils.createScriptWith(script, "last general", done);
+      utils.createScriptWith(script, 'last general', done);
     });
   }
 
@@ -133,7 +133,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
       done();
     });
 
-    it("pulls act and sequence from previous page to next page", function(done) {
+    it('pulls act and sequence from previous page to next page', function(done) {
       // wait for pagination to finish
       helper.waitFor(function() {
         var $lineAfterPageBreak = utils.linesAfterNonSplitPageBreaks().first();
@@ -147,7 +147,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
   //                            +--------- top of page --------+
   describe('(heading || shot) > (action || character || general)', function() {
     // FIXME flaky tests on this context. Might be related to https://trello.com/c/17moUuIt/316
-    context.skip("when first line of page is an action", function() {
+    context.skip('when first line of page is an action', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 4;
 
       before(function(done) {
@@ -156,18 +156,18 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and last line of previous page is a heading without act nor sequence", function() {
+      context('and last line of previous page is a heading without act nor sequence', function() {
         before(function(done) {
           changeLineBeforeBlockIntoHeading(firstLineOfBlock, done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "heading";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'heading';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and last line of previous page is a heading with act and sequence", function() {
+      context('and last line of previous page is a heading with act and sequence', function() {
         before(function(done) {
           changeLineToHeadingWithActAndSeq(firstLineOfBlock-1, done);
           this.timeout(5000);
@@ -176,7 +176,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoChangeToHeadingWithAS(done);
         });
 
-        it("pulls last line of previous page to next page, with its act and seq", function(done) {
+        it('pulls last line of previous page to next page, with its act and seq', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var $lineAfterPageBreak = utils.linesAfterNonSplitPageBreaks().first();
@@ -187,7 +187,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and last line of previous page is a shot", function() {
+      context('and last line of previous page is a shot', function() {
         before(function(done) {
           changeLineBeforeBlockIntoShot(firstLineOfBlock, done);
         });
@@ -195,13 +195,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "shot";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'shot';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and last line of previous page is something else", function() {
+      context('and last line of previous page is something else', function() {
         before(function(done) {
           changeLineBeforeBlockIntoSomethingElse(firstLineOfBlock, done);
         });
@@ -209,14 +209,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoChangeToSomethingElse(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "action";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'action';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
     });
 
-    context("when first line of page is a character", function() {
+    context('when first line of page is a character', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 4;
 
       before(function(done) {
@@ -225,7 +225,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context.skip("and last line of previous page is a heading", function() {
+      context.skip('and last line of previous page is a heading', function() {
         before(function(done) {
           changeLineBeforeBlockIntoHeading(firstLineOfBlock, done);
         });
@@ -237,13 +237,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "heading";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'heading';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and last line of previous page is a shot", function() {
+      context('and last line of previous page is a shot', function() {
         before(function(done) {
           changeLineBeforeBlockIntoShot(firstLineOfBlock, done);
         });
@@ -251,13 +251,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "shot";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'shot';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and last line of previous page is something else", function() {
+      context('and last line of previous page is something else', function() {
         before(function(done) {
           changeLineBeforeBlockIntoSomethingElse(firstLineOfBlock, done);
         });
@@ -265,21 +265,21 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoChangeToSomethingElse(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "character";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'character';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
     });
 
-    context("when first line of page is a general", function() {
+    context('when first line of page is a general', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 4;
 
       before(function(done) {
         createBaseScript(this, done);
       });
 
-      context.skip("and last line of previous page is a heading", function() {
+      context.skip('and last line of previous page is a heading', function() {
         before(function(done) {
           changeLineBeforeBlockIntoHeading(firstLineOfBlock, done);
         });
@@ -291,13 +291,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "heading";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'heading';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and last line of previous page is a shot", function() {
+      context('and last line of previous page is a shot', function() {
         before(function(done) {
           changeLineBeforeBlockIntoShot(firstLineOfBlock, done);
         });
@@ -305,13 +305,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "shot";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'shot';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and last line of previous page is something else", function() {
+      context('and last line of previous page is something else', function() {
         before(function(done) {
           // just change text of target line for clarity of test result on screen
           utils.getLine(firstLineOfBlock).sendkeys('{selectall}').sendkeys('another general');
@@ -321,12 +321,12 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoChangeToSomethingElse(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "another general";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'another general';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
 
-        it("does not add the MORE/CONT'D tags", function(done) {
+        it('does not add the MORE/CONT\'D tags', function(done) {
           utils.testPageBreakDoNotHaveMoreNorContd(done);
         });
       });
@@ -335,7 +335,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
   //                               +------ top of page ------+
   describe('!heading > character > (parenthetical || dialogue)', function() {
-    context("when first line of page is a parenthetical", function() {
+    context('when first line of page is a parenthetical', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 5;
 
       before(function(done) {
@@ -344,7 +344,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and previous line is a character and line before is not a heading", function() {
+      context('and previous line is a character and line before is not a heading', function() {
         before(function(done) {
           changeLineBeforeBlockIntoCharacter(firstLineOfBlock, done);
           // leave line before as general
@@ -353,8 +353,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "character";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'character';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -362,10 +362,10 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
       // FIXME UNDO is not reverting line back to original type when
       // adding a heading + creating its SMs + pressing UNDO.
       // see https://trello.com/c/CqWW4Sr2/943
-      context.skip("and previous line is a character and line before is a heading", function() {
+      context.skip('and previous line is a character and line before is a heading', function() {
         before(function(done) {
           // 4-line parenthetical, so it is long enough to be split if necessary
-          var fullLine = utils.buildStringWithLength(22, "1") + ". ";
+          var fullLine = utils.buildStringWithLength(22, '1') + '. ';
           var parentheticalText = fullLine + fullLine + fullLine + fullLine;
           var $topOfBlock = utils.getLine(firstLineOfBlock).find('parenthetical');
           $topOfBlock.sendkeys('{selectall}').sendkeys(parentheticalText);
@@ -386,14 +386,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls character and heading of previous page to next page", function(done) {
-          var firstLineOfNextPage = "heading";
+        it('pulls character and heading of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'heading';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
     });
 
-    context("when first line of page is a dialogue", function() {
+    context('when first line of page is a dialogue', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 5;
 
       before(function(done) {
@@ -402,7 +402,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and previous line is a character and line before is not a heading", function() {
+      context('and previous line is a character and line before is not a heading', function() {
         before(function(done) {
           changeLineBeforeBlockIntoCharacter(firstLineOfBlock, done);
           // leave line before as general
@@ -411,8 +411,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "character";
+        it('pulls last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'character';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -420,10 +420,10 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
       // FIXME UNDO is not reverting line back to original type when
       // adding a heading + creating its SMs + pressing UNDO.
       // see https://trello.com/c/CqWW4Sr2/943
-      context.skip("and previous line is a character and line before is a heading", function() {
+      context.skip('and previous line is a character and line before is a heading', function() {
         before(function(done) {
           // 4-line dialogue, so it is long enough to be split if necessary
-          var fullLine = utils.buildStringWithLength(32, "1") + ". ";
+          var fullLine = utils.buildStringWithLength(32, '1') + '. ';
           var parentheticalText = fullLine + fullLine + fullLine + fullLine;
           var $topOfBlock = utils.getLine(firstLineOfBlock).find('dialogue');
           $topOfBlock.sendkeys('{selectall}').sendkeys(parentheticalText);
@@ -444,8 +444,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls character and heading of previous page to next page", function(done) {
-          var firstLineOfNextPage = "heading";
+        it('pulls character and heading of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'heading';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -454,7 +454,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
   //                                                                          +------ top of page ------+
   describe('character > (parenthetical || dialogue) (only one line of text) > (parenthetical || dialogue)', function() {
-    context("when first line of page is a parenthetical", function() {
+    context('when first line of page is a parenthetical', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 5;
       var parentheticalText;
 
@@ -464,7 +464,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             changeLineBeforeBlockIntoDialogue(firstLineOfBlock, function() {
               changeLineBeforeBlockIntoCharacter(firstLineOfBlock-1, function() {
                 // 4-line parenthetical, so it is long enough to be split if necessary
-                var fullLine = utils.buildStringWithLength(22, "1") + ". ";
+                var fullLine = utils.buildStringWithLength(22, '1') + '. ';
                 parentheticalText = fullLine + fullLine + fullLine + fullLine;
                 var $topOfBlock = utils.getLine(firstLineOfBlock).find('parenthetical');
                 $topOfBlock.sendkeys('{selectall}').sendkeys(parentheticalText);
@@ -476,8 +476,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and dialogue on previous line has one line", function() {
-        it("pulls character and dialogue of previous page to next page", function(done) {
+      context('and dialogue on previous line has one line', function() {
+        it('pulls character and dialogue of previous page to next page', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var $firstLineOfNextPage = utils.linesAfterNonSplitPageBreaks().last();
@@ -485,14 +485,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
             return parentheticalIsNotOnTopOfPageAnymore;
           }).done(function() {
-            var firstLineOfNextPage = "character";
+            var firstLineOfNextPage = 'character';
             utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
           });
         });
       });
 
       // FIXME flaky tests on this context. Might be related to https://trello.com/c/17moUuIt/316
-      context.skip("and dialogue on previous line has more one line", function() {
+      context.skip('and dialogue on previous line has more one line', function() {
         before(function(done) {
           var $dialogue = utils.getLine(firstLineOfBlock-1).find('dialogue');
           $dialogue.sendkeys('{selectall}').sendkeys('a very very very very very long dialogue');
@@ -508,25 +508,25 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("adds the MORE/CONT'D tags with character name upper cased", function(done) {
+        it('adds the MORE/CONT\'D tags with character name upper cased', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
             return hasMoreTag;
           }).done(function() {
-            var characterName = "CHARACTER";
+            var characterName = 'CHARACTER';
             utils.testPageBreakHasMoreAndContd(characterName, done);
           });
         });
 
-        it("does not pull any line of previous page to next page", function(done) {
+        it('does not pull any line of previous page to next page', function(done) {
           var firstLineOfNextPage = parentheticalText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
     });
 
-    context("when first line of page is a dialogue", function() {
+    context('when first line of page is a dialogue', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 5;
       var parentheticalText;
 
@@ -536,7 +536,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             changeLineBeforeBlockIntoParenthetical(firstLineOfBlock, function() {
               changeLineBeforeBlockIntoCharacter(firstLineOfBlock-1, function() {
                 // 4-line dialogue, so it is long enough to be split if necessary
-                var fullLine = utils.buildStringWithLength(32, "1") + ". ";
+                var fullLine = utils.buildStringWithLength(32, '1') + '. ';
                 parentheticalText = fullLine + fullLine + fullLine + fullLine;
                 var $topOfBlock = utils.getLine(firstLineOfBlock).find('dialogue');
                 $topOfBlock.sendkeys('{selectall}').sendkeys(parentheticalText);
@@ -548,8 +548,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and parenthetical on previous line has one line", function() {
-        it("pulls character and parenthetical of previous page to next page", function(done) {
+      context('and parenthetical on previous line has one line', function() {
+        it('pulls character and parenthetical of previous page to next page', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var $firstLineOfNextPage = utils.linesAfterNonSplitPageBreaks().last();
@@ -557,14 +557,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
             return dialogueIsNotOnTopOfPageAnymore;
           }).done(function() {
-            var firstLineOfNextPage = "character";
+            var firstLineOfNextPage = 'character';
             utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
           });
         });
       });
 
       // FIXME flaky tests on this context. Might be related to https://trello.com/c/17moUuIt/316
-      context.skip("and parenthetical on previous line has more one line", function() {
+      context.skip('and parenthetical on previous line has more one line', function() {
         before(function(done) {
           var $parenthetical = utils.getLine(firstLineOfBlock-1).find('parenthetical');
           $parenthetical.sendkeys('{selectall}').sendkeys('a very very very very very long parenthetical');
@@ -580,18 +580,18 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("adds the MORE/CONT'D tags with character name upper cased", function(done) {
+        it('adds the MORE/CONT\'D tags with character name upper cased', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
             return hasMoreTag;
           }).done(function() {
-            var characterName = "CHARACTER";
+            var characterName = 'CHARACTER';
             utils.testPageBreakHasMoreAndContd(characterName, done);
           });
         });
 
-        it("does not pull any line of previous page to next page", function(done) {
+        it('does not pull any line of previous page to next page', function(done) {
           var firstLineOfNextPage = parentheticalText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
@@ -601,7 +601,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
   //                                                     +------------------ top of page ------------------+
   describe('!(character) > (parenthetical || dialogue) > (parenthetical || dialogue) (only one line of text) > !(parenthetical || dialogue)', function() {
-    context("when first line of page is a parenthetical, previous line is a dialogue, and line before is not a character", function() {
+    context('when first line of page is a parenthetical, previous line is a dialogue, and line before is not a character', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 6;
       var parentheticalText;
 
@@ -613,9 +613,9 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and next line is not a parenthetical nor a dialogue", function() {
-        context("and first line of page has one line", function() {
-          it("pulls last line of previous page to next page", function(done) {
+      context('and next line is not a parenthetical nor a dialogue', function() {
+        context('and first line of page has one line', function() {
+          it('pulls last line of previous page to next page', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var $firstLineOfNextPage = utils.linesAfterNonSplitPageBreaks().last();
@@ -623,13 +623,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
               return parentheticalIsNotOnTopOfPageAnymore;
             }).done(function() {
-              var firstLineOfNextPage = "dialogue";
+              var firstLineOfNextPage = 'dialogue';
               utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
             });
           });
         });
 
-        context("and first line of page has more one line", function() {
+        context('and first line of page has more one line', function() {
           var LONG_TEXT = 'a very very very very very long parenthetical';
 
           before(function(done) {
@@ -642,7 +642,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             undoLastChanges(done);
           });
 
-          it("does not pull last line of previous page to next page", function(done) {
+          it('does not pull last line of previous page to next page', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
@@ -655,7 +655,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and next line is a parenthetical", function() {
+      context('and next line is a parenthetical', function() {
         before(function(done) {
           changeLineTo(utils.PARENTHETICAL, 'another parenthetical', firstLineOfBlock+1, done);
         });
@@ -663,13 +663,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "parenthetical";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'parenthetical';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and next line is a dialogue", function() {
+      context('and next line is a dialogue', function() {
         before(function(done) {
           changeLineTo(utils.DIALOGUE, 'another dialogue', firstLineOfBlock+1, done);
         });
@@ -677,14 +677,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "parenthetical";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'parenthetical';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
     });
 
-    context("when first line of page is a dialogue, previous line is a parenthetical, and line before is not a character", function() {
+    context('when first line of page is a dialogue, previous line is a parenthetical, and line before is not a character', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 6;
       var parentheticalText;
 
@@ -696,9 +696,9 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and next line is not a dialogue nor a parenthetical", function() {
-        context("and first line of page has one line", function() {
-          it("pulls last line of previous page to next page", function(done) {
+      context('and next line is not a dialogue nor a parenthetical', function() {
+        context('and first line of page has one line', function() {
+          it('pulls last line of previous page to next page', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var $firstLineOfNextPage = utils.linesAfterNonSplitPageBreaks().last();
@@ -706,13 +706,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
               return dialogueIsNotOnTopOfPageAnymore;
             }).done(function() {
-              var firstLineOfNextPage = "parenthetical";
+              var firstLineOfNextPage = 'parenthetical';
               utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
             });
           });
         });
 
-        context("and first line of page has more one line", function() {
+        context('and first line of page has more one line', function() {
           var LONG_TEXT = 'a very very very very very long dialogue';
 
           before(function(done) {
@@ -725,7 +725,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             undoLastChanges(done);
           });
 
-          it("does not pull last line of previous page to next page", function(done) {
+          it('does not pull last line of previous page to next page', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
@@ -738,7 +738,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and next line is a dialogue", function() {
+      context('and next line is a dialogue', function() {
         before(function(done) {
           changeLineTo(utils.DIALOGUE, 'another dialogue', firstLineOfBlock+1, done);
         });
@@ -746,13 +746,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "dialogue";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'dialogue';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and next line is a parenthetical", function() {
+      context('and next line is a parenthetical', function() {
         before(function(done) {
           changeLineTo(utils.PARENTHETICAL, 'another parenthetical', firstLineOfBlock+1, done);
         });
@@ -760,8 +760,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "dialogue";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'dialogue';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -770,7 +770,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
   //                       +------------------ top of page ------------------+
   describe('!(character) > (parenthetical || dialogue) (only one line of text) > !(parenthetical || dialogue)', function() {
-    context("when first line of page is a parenthetical and previous line is not a character", function() {
+    context('when first line of page is a parenthetical and previous line is not a character', function() {
       var LAST_LINE_OF_PREV_PAGE = 'last general of previous page';
 
       var firstLineOfBlock = GENERALS_PER_PAGE + 6;
@@ -785,9 +785,9 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and next line is not a parenthetical nor a dialogue", function() {
-        context("and first line of page has one line", function() {
-          it("pulls last line of previous page to next page", function(done) {
+      context('and next line is not a parenthetical nor a dialogue', function() {
+        context('and first line of page has one line', function() {
+          it('pulls last line of previous page to next page', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var $firstLineOfNextPage = utils.linesAfterNonSplitPageBreaks().last();
@@ -801,7 +801,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           });
         });
 
-        context("and first line of page has more one line", function() {
+        context('and first line of page has more one line', function() {
           var LONG_TEXT = 'a very very very very very long parenthetical';
 
           before(function(done) {
@@ -814,7 +814,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             undoLastChanges(done);
           });
 
-          it("does not add the MORE/CONT'D tags", function(done) {
+          it('does not add the MORE/CONT\'D tags', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
@@ -824,14 +824,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             });
           });
 
-          it("does not pull last line of previous page to next page", function(done) {
+          it('does not pull last line of previous page to next page', function(done) {
             var firstLineOfNextPage = LONG_TEXT;
             utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
           });
         });
       });
 
-      context("and next line is a parenthetical", function() {
+      context('and next line is a parenthetical', function() {
         before(function(done) {
           changeLineTo(utils.PARENTHETICAL, 'another parenthetical', firstLineOfBlock+1, done);
         });
@@ -839,13 +839,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "parenthetical";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'parenthetical';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and next line is a dialogue", function() {
+      context('and next line is a dialogue', function() {
         before(function(done) {
           changeLineTo(utils.DIALOGUE, 'another dialogue', firstLineOfBlock+1, done);
         });
@@ -853,14 +853,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "parenthetical";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'parenthetical';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
     });
 
-    context("when first line of page is a dialogue and previous line is not a character", function() {
+    context('when first line of page is a dialogue and previous line is not a character', function() {
       var LAST_LINE_OF_PREV_PAGE = 'last general of previous page';
 
       var firstLineOfBlock = GENERALS_PER_PAGE + 6;
@@ -875,9 +875,9 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      context("and next line is not a dialogue nor a parenthetical", function() {
-        context("and first line of page has one line", function() {
-          it("pulls last line of previous page to next page", function(done) {
+      context('and next line is not a dialogue nor a parenthetical', function() {
+        context('and first line of page has one line', function() {
+          it('pulls last line of previous page to next page', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var $firstLineOfNextPage = utils.linesAfterNonSplitPageBreaks().last();
@@ -891,7 +891,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           });
         });
 
-        context("and first line of page has more one line", function() {
+        context('and first line of page has more one line', function() {
           var LONG_TEXT = 'a very very very very very long dialogue';
 
           before(function(done) {
@@ -904,7 +904,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             undoLastChanges(done);
           });
 
-          it("does not add the MORE/CONT'D tags", function(done) {
+          it('does not add the MORE/CONT\'D tags', function(done) {
             // wait for pagination to finish
             helper.waitFor(function() {
               var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
@@ -914,14 +914,14 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
             });
           });
 
-          it("does not pull last line of previous page to next page", function(done) {
+          it('does not pull last line of previous page to next page', function(done) {
             var firstLineOfNextPage = LONG_TEXT;
             utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
           });
         });
       });
 
-      context("and next line is a dialogue", function() {
+      context('and next line is a dialogue', function() {
         before(function(done) {
           changeLineTo(utils.DIALOGUE, 'another dialogue', firstLineOfBlock+1, done);
         });
@@ -929,13 +929,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "dialogue";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'dialogue';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
 
-      context("and next line is a parenthetical", function() {
+      context('and next line is a parenthetical', function() {
         before(function(done) {
           changeLineTo(utils.PARENTHETICAL, 'another parenthetical', firstLineOfBlock+1, done);
         });
@@ -943,8 +943,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("does not pull last line of previous page to next page", function(done) {
-          var firstLineOfNextPage = "dialogue";
+        it('does not pull last line of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'dialogue';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -953,7 +953,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
   //                                                                    +--------- $currentLine ---------+
   describe('(*) > (parenthetical || dialogue) (only one line of text) > transition (only one line of text)', function() {
-    context("when first line of page is a transition", function() {
+    context('when first line of page is a transition', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 5;
 
       before(function(done) {
@@ -972,8 +972,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last two lines of previous page to next page", function(done) {
-          var firstLineOfNextPage = "action";
+        it('pulls last two lines of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'action';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -986,8 +986,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last two lines of previous page to next page", function(done) {
-          var firstLineOfNextPage = "action";
+        it('pulls last two lines of previous page to next page', function(done) {
+          var firstLineOfNextPage = 'action';
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
         });
       });
@@ -996,7 +996,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
 
   //                                                                   +--------- $currentLine ---------+
   describe('(parenthetical || dialogue) (more than one line of text) > transition (only one line of text)', function() {
-    context("when first line of page is a transition", function() {
+    context('when first line of page is a transition', function() {
       var firstLineOfBlock = GENERALS_PER_PAGE + 5;
 
       before(function(done) {
@@ -1029,7 +1029,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
+        it('pulls last line of previous page to next page', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
@@ -1055,7 +1055,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
           undoLastChanges(done);
         });
 
-        it("pulls last line of previous page to next page", function(done) {
+        it('pulls last line of previous page to next page', function(done) {
           // wait for pagination to finish
           helper.waitFor(function() {
             var hasMoreTag = helper.padInner$('.withMoreAndContd').length > 0;
@@ -1073,7 +1073,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
   describe('(*) > transition (only one line of text)', function() {
     var firstLineOfBlock = GENERALS_PER_PAGE + 5;
 
-    context("when first line of page is a transition with one line", function() {
+    context('when first line of page is a transition with one line', function() {
       before(function(done) {
         createBaseScript(this, function() {
           changeLineTo(utils.TRANSITION, 'transition', firstLineOfBlock, function() {
@@ -1082,13 +1082,13 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      it("pulls last line of previous page to next page", function(done) {
-        var firstLineOfNextPage = "action";
+      it('pulls last line of previous page to next page', function(done) {
+        var firstLineOfNextPage = 'action';
         utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
       });
     });
 
-    context("when first line of page is a transition with more than one line", function() {
+    context('when first line of page is a transition with more than one line', function() {
       var LONG_TEXT = 'very long transition';
 
       before(function(done) {
@@ -1099,21 +1099,21 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         });
       });
 
-      it("does not pull last line of previous page to next page", function(done) {
-        var firstLineOfNextPage = "very long transition";
+      it('does not pull last line of previous page to next page', function(done) {
+        var firstLineOfNextPage = 'very long transition';
         utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfNextPage, done);
       });
     });
   });
 
-  context("when script has multiple pages and one of them has a block", function() {
+  context('when script has multiple pages and one of them has a block', function() {
     var sentences;
 
     before(function(done) {
-      var line1 = utils.buildStringWithLength(59, "1") + ". ";
-      var line2 = utils.buildStringWithLength(59, "2") + ". ";
-      var line3 = utils.buildStringWithLength(59, "3") + ". ";
-      var line4 = utils.buildStringWithLength(59, "4") + ". ";
+      var line1 = utils.buildStringWithLength(59, '1') + '. ';
+      var line2 = utils.buildStringWithLength(59, '2') + '. ';
+      var line3 = utils.buildStringWithLength(59, '3') + '. ';
+      var line4 = utils.buildStringWithLength(59, '4') + '. ';
       sentences = [line1, line2, line3, line4];
       targetLineText = line1 + line2 + line3 + line4;
 
@@ -1121,16 +1121,16 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
         var act          = utils.act('first act', 'summary of act');
         var seq          = utils.sequence('first sequence', 'summary of sequence');
         var firstHeading = utils.heading('first heading');
-        var firstPageAlmostFullOfGenerals  = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE - 5);
-        var secondPageAlmostFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE - 5);
+        var firstPageAlmostFullOfGenerals  = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE - 5);
+        var secondPageAlmostFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE - 5);
 
         // block of 1st page to be moved to 2nd page (5 lines high, including 2 lines for top margin)
-        var lastLineOfPreviousPage = utils.heading("heading");
-        var firstLineOfNextPage = utils.transition("transition");
+        var lastLineOfPreviousPage = utils.heading('heading');
+        var firstLineOfNextPage = utils.transition('transition');
 
         // element of 2nd page to be split between pages
         var lastBlock = utils.general(targetLineText);
-        var lastGeneral = utils.general("last general");
+        var lastGeneral = utils.general('last general');
 
         var script = act + seq + firstHeading +
                      firstPageAlmostFullOfGenerals +
@@ -1140,16 +1140,16 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
                      lastBlock +
                      lastGeneral;
 
-        utils.createScriptWith(script, "last general", done);
+        utils.createScriptWith(script, 'last general', done);
       });
     });
     after(function(done) {
       createBaseScript(this, done);
     });
 
-    it("considers the height of the resulting block without top margin", function(done) {
+    it('considers the height of the resulting block without top margin', function(done) {
       // test page break 1st => 2nd page
-      var firstLineOfSecondPage = "heading";
+      var firstLineOfSecondPage = 'heading';
       utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOfSecondPage, function() {
         // test page break 2nd => 3rd page
         var firstLineOfThirdPage = sentences[2];

--- a/static/tests/frontend/specs/lineNumberHeight.js
+++ b/static/tests/frontend/specs/lineNumberHeight.js
@@ -1,6 +1,6 @@
 // FIXME Line numbers are not aligned to correspondent text line
 // https://trello.com/c/hdZGr9EA/684
-describe.skip("ep_script_page_view - height of line numbers", function() {
+describe.skip('ep_script_page_view - height of line numbers', function() {
   var utils;
 
   before(function(){
@@ -14,13 +14,13 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
     this.timeout(60000);
   });
 
-  context("when pad has a non-split page break without MORE-CONTD", function() {
+  context('when pad has a non-split page break without MORE-CONTD', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
       // build script with one line on second page
-      var script = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE+1);
-      utils.createScriptWith(script, "general", function() {
+      var script = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE+1);
+      utils.createScriptWith(script, 'general', function() {
         // wait for pagination to finish before start testing
         helper.waitFor(function() {
           var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
@@ -29,26 +29,26 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
       });
     });
 
-    it("displays number of first line of next page on the top of its text", function(done) {
+    it('displays number of first line of next page on the top of its text', function(done) {
       var firstLineOfSecondPage = GENERALS_PER_PAGE+1;
       utils.testLineNumberIsOnTheSamePositionOfItsLineText(firstLineOfSecondPage, this, done);
     });
   });
 
-  context("when pad has a non-split page break with MORE-CONTD", function() {
+  context('when pad has a non-split page break with MORE-CONTD', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
       // build script with character => dialogue on first page, and parenthetical => dialogue
       // on second page (to have MORE/CONT'D)
-      var lastLineText = "last dialogue";
-      var fullLine = utils.buildStringWithLength(23, "1") + ". ";
+      var lastLineText = 'last dialogue';
+      var fullLine = utils.buildStringWithLength(23, '1') + '. ';
       // 2-line parenthetical
       var parentheticalText = fullLine + fullLine;
 
-      var pageFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE - 4);
-      var character = utils.character("character");
-      var dialogueOfPreviousPage = utils.dialogue("a very very very very very long dialogue");
+      var pageFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE - 4);
+      var character = utils.character('character');
+      var dialogueOfPreviousPage = utils.dialogue('a very very very very very long dialogue');
       var parentheticalOfNextPage = utils.parenthetical(parentheticalText);
       var dialogueOfNextPage = utils.dialogue(lastLineText);
 
@@ -63,21 +63,21 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
       });
     });
 
-    it("displays number of first line of next page on the top of its text", function(done) {
+    it('displays number of first line of next page on the top of its text', function(done) {
       var firstLineOfSecondPage = GENERALS_PER_PAGE-1;
       utils.testLineNumberIsOnTheSamePositionOfItsLineText(firstLineOfSecondPage, this, done);
     });
   });
 
-  context("when pad has a split page break without MORE-CONTD", function() {
+  context('when pad has a split page break without MORE-CONTD', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
       // build script with last line split between pages
-      var lastLineText = "last line";
-      var fullLine = utils.buildStringWithLength(59, "1") + ". ";
+      var lastLineText = 'last line';
+      var fullLine = utils.buildStringWithLength(59, '1') + '. ';
 
-      var pageFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE-1);
+      var pageFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE-1);
       var splitGeneral = utils.general(fullLine + fullLine);
       var lastLine = utils.general(lastLineText);
 
@@ -91,23 +91,23 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
       });
     });
 
-    it("displays number of first line of next page on the top of its text", function(done) {
+    it('displays number of first line of next page on the top of its text', function(done) {
       var firstLineOfSecondPage = GENERALS_PER_PAGE+1;
       utils.testLineNumberIsOnTheSamePositionOfItsLineText(firstLineOfSecondPage, this, done);
     });
   });
 
-  context("when pad has a split page break with MORE-CONTD", function() {
+  context('when pad has a split page break with MORE-CONTD', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
       // build script with very long parenthetical at the end of first page
-      var lastLineText = "last line";
-      var fullLine = utils.buildStringWithLength(23, "1") + ". ";
+      var lastLineText = 'last line';
+      var fullLine = utils.buildStringWithLength(23, '1') + '. ';
       // 4-line parenthetical (to be split)
       var parentheticalText = fullLine + fullLine + fullLine + fullLine;
 
-      var pageFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE - 3);
+      var pageFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE - 3);
       var longParenthetical = utils.parenthetical(parentheticalText);
       var lastLine = utils.general(lastLineText);
 
@@ -122,7 +122,7 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
       });
     });
 
-    it("displays number of first line of next page on the top of its text", function(done) {
+    it('displays number of first line of next page on the top of its text', function(done) {
       var firstLineOfSecondPage = GENERALS_PER_PAGE-2;
       utils.testLineNumberIsOnTheSamePositionOfItsLineText(firstLineOfSecondPage, this, done);
     });

--- a/static/tests/frontend/specs/otherMoreContd.js
+++ b/static/tests/frontend/specs/otherMoreContd.js
@@ -1,4 +1,4 @@
-describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
+describe.skip('ep_script_page_view - other MORE/CONT\'D tests', function() {
   var utils, scriptBuilder, lastLineText;
 
   before(function(){
@@ -14,16 +14,16 @@ describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
     this.timeout(60000);
   });
 
-  context("when first page ends on a dialogue and second page starts on a parenthetical", function() {
+  context('when first page ends on a dialogue and second page starts on a parenthetical', function() {
     before(function() {
       scriptBuilder = function() {
-        var line1 = utils.buildStringWithLength(23, "1") + ". ";
-        var line2 = utils.buildStringWithLength(23, "2") + ". ";
+        var line1 = utils.buildStringWithLength(23, '1') + '. ';
+        var line2 = utils.buildStringWithLength(23, '2') + '. ';
         var longParenthetical = line1 + line2;
-        lastLineText = "last general";
+        lastLineText = 'last general';
 
-        var generals      = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE-2);
-        var dialogue      = utils.dialogue("dialogue");
+        var generals      = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE-2);
+        var dialogue      = utils.dialogue('dialogue');
         var parenthetical = utils.parenthetical(longParenthetical);
         var lastGeneral   = utils.general(lastLineText);
 
@@ -31,22 +31,22 @@ describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
       };
     });
 
-    it("adds the MORE/CONT'D tags", function(done) {
-      var noCharacter = "";
+    it('adds the MORE/CONT\'D tags', function(done) {
+      var noCharacter = '';
       utils.testPageBreakHasMoreAndContd(noCharacter, done);
     });
   });
 
-  context("when first page ends on a parenthetical and second page starts on a dialogue", function() {
+  context('when first page ends on a parenthetical and second page starts on a dialogue', function() {
     before(function() {
       scriptBuilder = function() {
-        var line1 = utils.buildStringWithLength(33, "1") + ". ";
-        var line2 = utils.buildStringWithLength(33, "2") + ". ";
+        var line1 = utils.buildStringWithLength(33, '1') + '. ';
+        var line2 = utils.buildStringWithLength(33, '2') + '. ';
         var longDialogue = line1 + line2;
-        lastLineText = "last general";
+        lastLineText = 'last general';
 
-        var generals      = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE-2);
-        var parenthetical = utils.parenthetical("parenthetical");
+        var generals      = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE-2);
+        var parenthetical = utils.parenthetical('parenthetical');
         var dialogue      = utils.dialogue(longDialogue);
         var lastGeneral   = utils.general(lastLineText);
 
@@ -54,8 +54,8 @@ describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
       };
     });
 
-    it("adds the MORE/CONT'D tags", function(done) {
-      var noCharacter = "";
+    it('adds the MORE/CONT\'D tags', function(done) {
+      var noCharacter = '';
       utils.testPageBreakHasMoreAndContd(noCharacter, done);
     });
   });

--- a/static/tests/frontend/specs/repaginate.js
+++ b/static/tests/frontend/specs/repaginate.js
@@ -1,4 +1,4 @@
-describe.skip("ep_script_page_view - repaginate", function() {
+describe.skip('ep_script_page_view - repaginate', function() {
   var utils, smUtils;
 
   before(function(){
@@ -13,11 +13,11 @@ describe.skip("ep_script_page_view - repaginate", function() {
     this.timeout(60000);
   });
 
-  context("when user inserts text on a line", function() {
+  context('when user inserts text on a line', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // build script full of generals and with one line on second page
       var script = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE + 1);
@@ -30,14 +30,14 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("repaginates pad from 3 lines above changed line", function(done) {
+    it('repaginates pad from 3 lines above changed line', function(done) {
       this.timeout(4000);
 
       // insert text on line before page break to make it be 2 inner lines long
-      var fullLine = utils.buildStringWithLength(59, "1") + ". ";
+      var fullLine = utils.buildStringWithLength(59, '1') + '. ';
       var $lineBeforePageBreak = utils.linesAfterNonSplitPageBreaks().last().prev();
-      $lineBeforePageBreak.sendkeys("{selectall}{rightarrow}");
-      // first page will have "general. ", second page will have fullLine
+      $lineBeforePageBreak.sendkeys('{selectall}{rightarrow}');
+      // first page will have 'general. ', second page will have fullLine
       $lineBeforePageBreak.sendkeys('. ' + fullLine);
 
       // wait for pagination to be re-run
@@ -55,22 +55,22 @@ describe.skip("ep_script_page_view - repaginate", function() {
     });
   });
 
-  context("when user removes text from a line", function() {
+  context('when user removes text from a line', function() {
     var firstHalfOfSplit, secondHalfOfSplit;
 
     before(function() {
-      firstHalfOfSplit = utils.buildStringWithLength(24, "1") + ". ";
-      secondHalfOfSplit = utils.buildStringWithLength(24, "2") + ". ";
+      firstHalfOfSplit = utils.buildStringWithLength(24, '1') + '. ';
+      secondHalfOfSplit = utils.buildStringWithLength(24, '2') + '. ';
     });
 
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var textToBeRemoved = "<b>remove me.</b>";
-      var lastLineText = "last general";
+      var textToBeRemoved = '<b>remove me.</b>';
+      var lastLineText = 'last general';
 
       // build script full of generals + a very long general (split between pages) + another general
-      var pageFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE - 1);
+      var pageFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE - 1);
       var splitGeneral       = utils.general(firstHalfOfSplit + textToBeRemoved + secondHalfOfSplit);
       var lastGeneral        = utils.general(lastLineText);
       var script             = pageFullOfGenerals + splitGeneral + lastGeneral;
@@ -84,14 +84,14 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("repaginates pad from 3 lines above changed line", function(done) {
+    it('repaginates pad from 3 lines above changed line', function(done) {
       this.timeout(4000);
 
       var inner$ = helper.padInner$;
 
       // remove text from split line to make it be 1 inner line long
-      var $textToBeRemoved = inner$("div b");
-      $textToBeRemoved.sendkeys("{selectall}{backspace}");
+      var $textToBeRemoved = inner$('div b');
+      $textToBeRemoved.sendkeys('{selectall}{backspace}');
 
       // wait for pagination to be re-run
       helper.waitFor(function() {
@@ -109,23 +109,23 @@ describe.skip("ep_script_page_view - repaginate", function() {
     });
   });
 
-  context("when user removes a full line", function() {
+  context('when user removes a full line', function() {
     var textToBeOnTopOfSecondPage;
     before(function() {
-      textToBeOnTopOfSecondPage = "But I will go to first page when this test is done";
+      textToBeOnTopOfSecondPage = 'But I will go to first page when this test is done';
     });
 
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "last general";
-      var firstHalfOfSplit = "I'm supposed to be on second page before line is removed... ";
+      var lastLineText = 'last general';
+      var firstHalfOfSplit = 'I am supposed to be on second page before line is removed... ';
       var secondHalfOfSplit = textToBeOnTopOfSecondPage;
 
       // build script with a general to be removed + page full of generals +
       // a very long general (to be split between pages) + another general
-      var lineToBeRemoved             = utils.general("remove me");
-      var pageFullOfGenerals          = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE - 1);
+      var lineToBeRemoved             = utils.general('remove me');
+      var pageFullOfGenerals          = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE - 1);
       var lineToBeAtBottomOfFirstPage = utils.general(firstHalfOfSplit + secondHalfOfSplit);
       var lastGeneral                 = utils.general(lastLineText);
 
@@ -139,18 +139,18 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("repaginates pad from 3 lines above changed line", function(done) {
+    it('repaginates pad from 3 lines above changed line', function(done) {
       this.timeout(4000);
 
       var inner$ = helper.padInner$;
 
       // remove first line to make move lines after it one position up
-      var $firstLine = inner$("div").first();
+      var $firstLine = inner$('div').first();
       // place caret on line to be removed so Etherpad notices there was a change on DOM
-      $firstLine.sendkeys("{selectall}");
+      $firstLine.sendkeys('{selectall}');
       // cannot use sendkeys because it would only remove text inside <div>, we need to remove
       // the <div> itself
-      $firstLine.get(0).outerHTML = "";
+      $firstLine.get(0).outerHTML = '';
 
       // wait for pagination to be re-run
       helper.waitFor(function() {
@@ -167,13 +167,13 @@ describe.skip("ep_script_page_view - repaginate", function() {
     });
   });
 
-  context("when user changes the type of a line", function() {
+  context('when user changes the type of a line', function() {
     var buildLineToBeChanged, numberOfGeneralsBeforeHeading;
 
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "last general";
+      var lastLineText = 'last general';
 
       // build script full of generals + a heading + a character + the line to be changed + another general
       var act                = utils.act('first act', 'summary of act');
@@ -181,10 +181,10 @@ describe.skip("ep_script_page_view - repaginate", function() {
       var firstHeading       = utils.heading('first heading');
       // to make tests easier, replace the first general by a heading with act+seq, so the next
       // heading doesn't need to have any scene mark
-      var pageFullOfGenerals = utils.buildScriptWithGenerals("general", numberOfGeneralsBeforeHeading - 1);
-      var heading            = utils.heading("heading");
-      var character          = utils.character("character");
-      var lineToBeChanged    = buildLineToBeChanged("I'll be changed");
+      var pageFullOfGenerals = utils.buildScriptWithGenerals('general', numberOfGeneralsBeforeHeading - 1);
+      var heading            = utils.heading('heading');
+      var character          = utils.character('character');
+      var lineToBeChanged    = buildLineToBeChanged('I will be changed');
       var lastGeneral        = utils.general(lastLineText);
 
       var script = act + seq + firstHeading
@@ -202,7 +202,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    context("and new line type builds a block of lines", function() {
+    context('and new line type builds a block of lines', function() {
       before(function() {
         numberOfGeneralsBeforeHeading = GENERALS_PER_PAGE - 5;
         buildLineToBeChanged = function(text) {
@@ -210,7 +210,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
         };
       });
 
-      it("repaginates pad from 3 lines above changed line", function(done) {
+      it('repaginates pad from 3 lines above changed line', function(done) {
         this.timeout(4000);
 
         // +7: act + seq + synopsis + 1st heading
@@ -226,13 +226,13 @@ describe.skip("ep_script_page_view - repaginate", function() {
             // now we have a heading on top of second page
             var $firstLineOfSecondPage = utils.linesAfterNonSplitPageBreaks().first();
             var $firstScriptElementOfSecondPage = utils.getFirstScriptElementOfPageStartingAt($firstLineOfSecondPage);
-            return $firstScriptElementOfSecondPage.text() === "heading";
+            return $firstScriptElementOfSecondPage.text() === 'heading';
           }, 2000).done(done);
         });
       });
     });
 
-    context("and new line type destroys a block of lines", function() {
+    context('and new line type destroys a block of lines', function() {
       var textOfChangedLine;
 
       before(function() {
@@ -243,7 +243,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
         };
       });
 
-      it("repaginates pad from 3 lines above changed line", function(done) {
+      it('repaginates pad from 3 lines above changed line', function(done) {
         this.timeout(4000);
 
         var lineNumberToBeChanged = 7 + numberOfGeneralsBeforeHeading + 4 - 1;
@@ -262,7 +262,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    context("and changed line is not one of the first 3 lines of a page", function() {
+    context('and changed line is not one of the first 3 lines of a page', function() {
       var originalIdOfFirstLineWithPageBreak, originalIdOfLastLineWithPageBreak;
 
       before(function() {
@@ -277,15 +277,15 @@ describe.skip("ep_script_page_view - repaginate", function() {
 
         var inner$ = helper.padInner$;
 
-        var lastLineText = "last general";
+        var lastLineText = 'last general';
         var changedLine = GENERALS_PER_PAGE + 11;
 
         // we need another page break for this scenario, so add another page full of generals
-        var pageFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE);
+        var pageFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE);
         var lastGeneral        = utils.general(lastLineText);
 
         var anotherPage = pageFullOfGenerals + lastGeneral;
-        var $lastLine = inner$("div").last();
+        var $lastLine = inner$('div').last();
         $lastLine.html(anotherPage);
 
         // wait for pagination to finish
@@ -294,9 +294,9 @@ describe.skip("ep_script_page_view - repaginate", function() {
           return $linesWithPageBreaks.length > 1;
         }, 3000).done(function() {
           // store ids of lines with page break to verify later if they had changed
-          var $linesWithPageBreaks           = inner$("div:has(nonsplitpagebreak)");
-          originalIdOfFirstLineWithPageBreak = $linesWithPageBreaks.first().attr("id");
-          originalIdOfLastLineWithPageBreak  = $linesWithPageBreaks.last().attr("id");
+          var $linesWithPageBreaks           = inner$('div:has(nonsplitpagebreak)');
+          originalIdOfFirstLineWithPageBreak = $linesWithPageBreaks.first().attr('id');
+          originalIdOfLastLineWithPageBreak  = $linesWithPageBreaks.last().attr('id');
 
           // change line on bottom of block (heading => character => dialogue) to destroy the block
           smUtils.changeLineToElement(utils.GENERAL, changedLine, function() {
@@ -305,7 +305,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
               // id of line with last page break should be different
               var $linesAfterPageBreaks = utils.linesAfterNonSplitPageBreaks();
               var $lineWithLastPageBreak = $linesAfterPageBreaks.last().prev();
-              var newIdOfLastLineWithPageBreak = $lineWithLastPageBreak.attr("id");
+              var newIdOfLastLineWithPageBreak = $lineWithLastPageBreak.attr('id');
 
               return ($linesAfterPageBreaks.length === 2) && (newIdOfLastLineWithPageBreak !== originalIdOfLastLineWithPageBreak);
             }, 2000).done(done);
@@ -313,39 +313,39 @@ describe.skip("ep_script_page_view - repaginate", function() {
         });
       });
 
-      it("does not repaginate pad 3 lines above changed line", function(done) {
+      it('does not repaginate pad 3 lines above changed line', function(done) {
         this.timeout(4000);
 
         // id of line with first page break should be the same
         var $linesAfterPageBreaks = utils.linesAfterNonSplitPageBreaks();
         var $lineWithFirstPageBreak = $linesAfterPageBreaks.first().prev();
-        var actualIdOfFirstLineWithPageBreak = $lineWithFirstPageBreak.attr("id");
+        var actualIdOfFirstLineWithPageBreak = $lineWithFirstPageBreak.attr('id');
 
         expect(actualIdOfFirstLineWithPageBreak).to.be(originalIdOfFirstLineWithPageBreak);
 
         done();
       });
 
-      it("assigns new page numbers according to the number of the last unchanged page", function(done) {
+      it('assigns new page numbers according to the number of the last unchanged page', function(done) {
         this.timeout(4000);
 
         var $linesAfterPageBreaks = utils.linesAfterNonSplitPageBreaks();
         var $lineAfterSecondPageBreak = $linesAfterPageBreaks.last();
 
-        var actualPageNumber = utils.pageBreakOfLine($lineAfterSecondPageBreak).closest("div").find("pagenumber").attr("data-page-number");
-        expect(actualPageNumber.toString()).to.be("3");
+        var actualPageNumber = utils.pageBreakOfLine($lineAfterSecondPageBreak).closest('div').find('pagenumber').attr('data-page-number');
+        expect(actualPageNumber.toString()).to.be('3');
 
         done();
       });
     });
   });
 
-  context("when user starts a char composition", function() {
+  context('when user starts a char composition', function() {
     var originalIdOfLastLineWithPageBreak;
 
     var getIdOfLineWithLastPageBreak = function() {
       var $lineWithPageBreak = utils.linesAfterNonSplitPageBreaks().last().prev();
-      var currentIdOfLineWithLastPageBreak = $lineWithPageBreak.attr("id");
+      var currentIdOfLineWithLastPageBreak = $lineWithPageBreak.attr('id');
 
       return currentIdOfLineWithLastPageBreak;
     }
@@ -363,10 +363,10 @@ describe.skip("ep_script_page_view - repaginate", function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "last line";
+      var lastLineText = 'last line';
 
       // build script with several pages full of generals + a final general
-      var pageFullOfGenerals = utils.buildScriptWithGenerals("general", GENERALS_PER_PAGE);
+      var pageFullOfGenerals = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE);
       var pages              = pageFullOfGenerals.repeat(7);
       var lastGeneral        = utils.general(lastLineText);
       var script             = pages + lastGeneral;
@@ -389,7 +389,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("does not repaginate any part of the script", function(done) {
+    it('does not repaginate any part of the script', function(done) {
       this.timeout(2100);
 
       helper.waitFor(function() {
@@ -408,7 +408,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
         done();
       });
 
-      it("repaginates the script", function(done) {
+      it('repaginates the script', function(done) {
         this.timeout(2100);
 
         helper.waitFor(function() {
@@ -419,11 +419,11 @@ describe.skip("ep_script_page_view - repaginate", function() {
     });
   });
 
-  context("when line after a page break has top margin", function() {
+  context('when line after a page break has top margin', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // build script with a heading on top of script + 1st page almost full (leave two lines at
       // the end) + one heading on top of 2nd page + another full page + a single line on 3rd page
@@ -433,7 +433,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
       // to make tests easier, replace the first general by a heading with act+seq, so the next
       // heading doesn't need to have any scene mark without any scene mark
       var pageAlmostFullOfGenerals = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE - 3);
-      var heading = utils.heading("heading");
+      var heading = utils.heading('heading');
       var pageFullOfGenerals = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE);
       var script = act + seq + firstHeading + pageAlmostFullOfGenerals + heading + pageFullOfGenerals;
 
@@ -446,15 +446,15 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("recalculates page breaks taking into account the future margin element will have if it isn't after page break", function(done) {
+    it('recalculates page breaks taking into account the future margin element will have if it is not after page break', function(done) {
       this.timeout(4000);
 
       var inner$ = helper.padInner$;
 
       // remove line after heading, so there will be one less page break
-      var $lineAfterHeading = inner$("div:has(heading)").last().next();
-      $lineAfterHeading.sendkeys("{selectall}");
-      $lineAfterHeading.get(0).outerHTML = "";
+      var $lineAfterHeading = inner$('div:has(heading)').last().next();
+      $lineAfterHeading.sendkeys('{selectall}');
+      $lineAfterHeading.get(0).outerHTML = '';
 
       // wait for repagination to finish
       helper.waitFor(function() {
@@ -465,24 +465,24 @@ describe.skip("ep_script_page_view - repaginate", function() {
         // (1 for text and 2 for top margin), so it should still be on top of 2nd page
         var $firstLineOfSecondPage = utils.linesAfterNonSplitPageBreaks().first();
         var $firstScriptElementOfSecondPage = utils.getFirstScriptElementOfPageStartingAt($firstLineOfSecondPage);
-        expect($firstScriptElementOfSecondPage.text()).to.be("heading");
+        expect($firstScriptElementOfSecondPage.text()).to.be('heading');
 
         done();
       });
     });
   });
 
-  context("when a non-split line with page break is repaginated and split", function() {
+  context('when a non-split line with page break is repaginated and split', function() {
     var lines;
 
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // build script full of generals and with last line with 2 inner lines
-      var line1 = "AA" + utils.buildStringWithLength(50, "1") + ". ";
-      var line2 = "BB" + utils.buildStringWithLength(50, "2") + ". ";
+      var line1 = 'AA' + utils.buildStringWithLength(50, '1') + '. ';
+      var line2 = 'BB' + utils.buildStringWithLength(50, '2') + '. ';
       lines = [line1, line2];
 
       var fullPage = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE - 2) +
@@ -499,14 +499,14 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("splits line after last whitespace that fits on previous page", function(done) {
+    it('splits line after last whitespace that fits on previous page', function(done) {
       this.timeout(4000);
 
       var inner$ = helper.padInner$;
 
       // insert text on first line to change page break from non-split to split
-      var longText = utils.buildStringWithLength(62, "1");
-      var $firstLine = inner$("div").first();
+      var longText = utils.buildStringWithLength(62, '1');
+      var $firstLine = inner$('div').first();
       $firstLine.sendkeys(longText);
 
       // wait for pagination to be re-run
@@ -525,14 +525,14 @@ describe.skip("ep_script_page_view - repaginate", function() {
     });
   });
 
-  context("when user expands the scene marks of a scene", function() {
+  context('when user expands the scene marks of a scene', function() {
     var originalIdOfLineWithPageBreak;
 
     var HEADING_LINE = 4;
 
     var getIdOfLineWithPageBreak = function() {
       var $lineWithPageBreak = utils.linesAfterNonSplitPageBreaks().first().prev();
-      var currentIdOfLineWithPageBreak = $lineWithPageBreak.attr("id");
+      var currentIdOfLineWithPageBreak = $lineWithPageBreak.attr('id');
 
       return currentIdOfLineWithPageBreak;
     }
@@ -561,7 +561,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // build script with a heading on top of script + 1st page full of generals + 1 line on 2nd page
       var act                = utils.act('first act', 'summary of act');
@@ -588,7 +588,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
       });
     });
 
-    it("does not repaginate any part of the script", function(done) {
+    it('does not repaginate any part of the script', function(done) {
       // id of line with first page break should be the same
       var currentIdOfLineWithPageBreak = getIdOfLineWithPageBreak();
 
@@ -602,7 +602,7 @@ describe.skip("ep_script_page_view - repaginate", function() {
         clickToHideSceneMarks(done);
       });
 
-      it("does not repaginate any part of the script", function(done) {
+      it('does not repaginate any part of the script', function(done) {
         // id of line with first page break should be the same
         var currentIdOfLineWithPageBreak = getIdOfLineWithPageBreak();;
 

--- a/static/tests/frontend/specs/scroll.js
+++ b/static/tests/frontend/specs/scroll.js
@@ -1,4 +1,4 @@
-describe.skip("ep_script_page_view - scroll", function() {
+describe.skip('ep_script_page_view - scroll', function() {
   var utils;
 
   before(function(){
@@ -12,11 +12,11 @@ describe.skip("ep_script_page_view - scroll", function() {
     this.timeout(60000);
   });
 
-  context("when user edits a line with page break", function() {
+  context('when user edits a line with page break', function() {
     beforeEach(function(done) {
       this.timeout(4000);
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // build script full of generals with 2 page breaks
       var script = utils.buildScriptWithGenerals(lastLineText, 3*GENERALS_PER_PAGE);
@@ -29,13 +29,13 @@ describe.skip("ep_script_page_view - scroll", function() {
       });
     });
 
-    it("keeps line with caret on same position of viewport", function(done) {
+    it('keeps line with caret on same position of viewport', function(done) {
       this.timeout(3000);
 
       var lastLineOfSecondPage = 2*GENERALS_PER_PAGE-1;
       utils.moveViewportToLine(lastLineOfSecondPage);
 
-      utils.getLine(lastLineOfSecondPage).sendkeys("changed ");
+      utils.getLine(lastLineOfSecondPage).sendkeys('changed ');
 
       // this scenario failed only when editing a line with non-split page break that resulted
       // in a new non-split page break, so there's nothing we can do to avoid the timeout here
@@ -45,14 +45,14 @@ describe.skip("ep_script_page_view - scroll", function() {
       }, 1000);
     });
 
-    context("and edited line is split", function() {
+    context('and edited line is split', function() {
       var lastLineOfSecondPage = 2*GENERALS_PER_PAGE-1;
 
       beforeEach(function (done) {
         this.timeout(3000);
 
         // make line a split line, but leave room for some more text at the end of 1st half
-        var longText = utils.buildStringWithLength(57, "1") + " ";
+        var longText = utils.buildStringWithLength(57, '1') + ' ';
         utils.getLine(lastLineOfSecondPage).sendkeys(longText);
 
         // wait for pagination to finish before start testing
@@ -62,26 +62,26 @@ describe.skip("ep_script_page_view - scroll", function() {
         }, 2000).done(done);
       });
 
-      it("keeps line with caret on same position of viewport when edit 1st half of split", function(done) {
+      it('keeps line with caret on same position of viewport when edit 1st half of split', function(done) {
         this.timeout(3000);
 
         utils.moveViewportToLine(lastLineOfSecondPage);
 
-        var placeCaretOnSecondColumn = "{selectall}{leftarrow}{rightarrow}";
+        var placeCaretOnSecondColumn = '{selectall}{leftarrow}{rightarrow}';
         var $targetLine = utils.getLine(lastLineOfSecondPage);
         $targetLine.sendkeys(placeCaretOnSecondColumn);
-        $targetLine.sendkeys(". 111"); // first half will have only "1. "
+        $targetLine.sendkeys('. 111'); // first half will have only '1. '
 
         // wait for pagination to finish before start testing
         helper.waitFor(function() {
           var $lineBeforePageBreak = utils.linesAfterSplitPageBreaks().first().prev();
-          return utils.cleanText($lineBeforePageBreak.text()) === utils.cleanText("1. ");
+          return utils.cleanText($lineBeforePageBreak.text()) === utils.cleanText('1. ');
         }, 2000).done(function() {
           utils.testLineIsOnTopOfViewport(lastLineOfSecondPage, done);
         });
       });
 
-      it("keeps line with caret on same position of viewport when edit 2nd half of split", function(done) {
+      it('keeps line with caret on same position of viewport when edit 2nd half of split', function(done) {
         this.timeout(3000);
 
         var firstLineOfThirdPage = lastLineOfSecondPage + 1;
@@ -89,13 +89,13 @@ describe.skip("ep_script_page_view - scroll", function() {
         utils.moveViewportToLine(firstLineOfThirdPage);
 
         // need to get line inner tag to call sendkeys(), otherwise it will destroy split data
-        var $targetLine = utils.getLine(firstLineOfThirdPage).find("split_second_half");
-        $targetLine.sendkeys("1. "); // "1. " will be moved to first half
+        var $targetLine = utils.getLine(firstLineOfThirdPage).find('split_second_half');
+        $targetLine.sendkeys('1. '); // '1. ' will be moved to first half
 
         // wait for pagination to finish before start testing
         helper.waitFor(function() {
           var $lineAfterPageBreak = utils.linesAfterSplitPageBreaks().first();
-          return $lineAfterPageBreak.text() === "general";
+          return $lineAfterPageBreak.text() === 'general';
         }, 2000).done(function() {
           utils.testLineIsOnTopOfViewport(firstLineOfThirdPage, done);
         });
@@ -103,7 +103,7 @@ describe.skip("ep_script_page_view - scroll", function() {
     });
   });
 
-  context("when user changes viewport to a line not repaginated yet", function() {
+  context('when user changes viewport to a line not repaginated yet', function() {
     var MAX_PAGE_BREAKS_PER_CYCLE = 5;
     var DO_NOT_MOVE_CARET = -1;
 
@@ -119,7 +119,7 @@ describe.skip("ep_script_page_view - scroll", function() {
     var targetLineNumberAfterFullRepaginationWithSplitPageBreaks = function() {
       // after repagination is complete, each page end with a split line,
       // so there will be NUMBER_OF_PAGES extra lines on script (NUMBER_OF_PAGES - 1 before
-      // the "page before last")
+      // the 'page before last')
       var pageBeforeLast = NUMBER_OF_PAGES - 1;
       return targetLineNumber + pageBeforeLast - 1;
     }
@@ -162,12 +162,12 @@ describe.skip("ep_script_page_view - scroll", function() {
 
       var inner$ = helper.padInner$;
 
-      var lastLineText = "general";
+      var lastLineText = 'general';
 
       // each page has several single-line generals, and last line is a two-lines general
       // (so it is split later)
-      var line1 = utils.buildStringWithLength(50, "1") + ". ";
-      var line2 = utils.buildStringWithLength(50, "2") + ". ";
+      var line1 = utils.buildStringWithLength(50, '1') + '. ';
+      var line2 = utils.buildStringWithLength(50, '2') + '. ';
       var fullPage = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE - 2) +
                      utils.general(line1 + line2);
       var lastLine = utils.general(lastLineText);
@@ -180,20 +180,20 @@ describe.skip("ep_script_page_view - scroll", function() {
         }, 10000).done(function() {
           // change target line text, to be easier to visualize what should be on top of viewport
           var $targetLine = utils.getLine(targetLineNumber);
-          $targetLine.sendkeys("{selectall}{backspace}");
+          $targetLine.sendkeys('{selectall}{backspace}');
           $targetLine.sendkeys(targetLineText);
 
           // change caret line text too, if needed
           if (caretLineNumber !== DO_NOT_MOVE_CARET) {
             var $caretLine = utils.getLine(caretLineNumber);
-            $caretLine.sendkeys("{selectall}{backspace}");
-            $caretLine.sendkeys("This is the line where caret will be");
+            $caretLine.sendkeys('{selectall}{backspace}');
+            $caretLine.sendkeys('This is the line where caret will be');
           }
 
           // inserts a long text to first line, so all lines will be shift one line down
           // and pagination will change scroll position of elements
-          var longText = utils.buildStringWithLength(62, "1");
-          var $firstLine = inner$("div").first();
+          var longText = utils.buildStringWithLength(62, '1');
+          var $firstLine = inner$('div').first();
           $firstLine.sendkeys(longText);
 
           // wait for first cycle of repagination to be completed before moving caret and viewport
@@ -212,7 +212,7 @@ describe.skip("ep_script_page_view - scroll", function() {
       });
     });
 
-    context("and line on top of viewport does not receive a page break", function() {
+    context('and line on top of viewport does not receive a page break', function() {
       before(function() {
         var middleOfPage = GENERALS_PER_PAGE/2;
         var linesPerPage = GENERALS_PER_PAGE - 1; // -1: each page has a double-line at the end
@@ -220,10 +220,10 @@ describe.skip("ep_script_page_view - scroll", function() {
         var middleOfPageBeforeLast = pageBeforeLast * linesPerPage - middleOfPage;
 
         targetLineNumber = middleOfPageBeforeLast;
-        targetLineText = "This line should be on top of viewport";
+        targetLineText = 'This line should be on top of viewport';
       });
 
-      it("keeps first visible line always on top of viewport", function(done) {
+      it('keeps first visible line always on top of viewport', function(done) {
         this.timeout(14000);
 
         // check if viewport is still where it should be after repagination is complete
@@ -236,11 +236,11 @@ describe.skip("ep_script_page_view - scroll", function() {
       });
     });
 
-    context("and line on top of viewport receives a page break", function() {
+    context('and line on top of viewport receives a page break', function() {
       before(function() {
         targetLineNumber = lastLineOfPageBeforeLast();
         // as target line is a double-line, keep it that way and use a long text
-        targetLineText = "This very very very very very long line should be on top of viewport";
+        targetLineText = 'This very very very very very long line should be on top of viewport';
       });
 
       beforeEach(function(done) {
@@ -253,12 +253,12 @@ describe.skip("ep_script_page_view - scroll", function() {
         }, 10000).done(done);
       });
 
-      it("keeps first visible line always on top of viewport", function(done) {
+      it('keeps first visible line always on top of viewport', function(done) {
         var lineNumberAfterFullRepagination = targetLineNumberAfterFullRepaginationWithSplitPageBreaks();
         utils.testLineIsOnTopOfViewport(lineNumberAfterFullRepagination, done);
       });
 
-      context("then line on top of viewport has its page break removed", function() {
+      context('then line on top of viewport has its page break removed', function() {
         var lineNumberAfterFirstCycle, editFirstLine;
 
         beforeEach(function(done) {
@@ -282,35 +282,35 @@ describe.skip("ep_script_page_view - scroll", function() {
           });
         });
 
-        context("and line is moved above a page break", function() {
+        context('and line is moved above a page break', function() {
           before(function() {
             editFirstLine = function() {
               var inner$ = helper.padInner$;
 
               // edit first line to make it have one inner line only
-              var $firstLine = inner$("div").first();
-              $firstLine.sendkeys("{selectall}{backspace}");
-              $firstLine.sendkeys("general");
+              var $firstLine = inner$('div').first();
+              $firstLine.sendkeys('{selectall}{backspace}');
+              $firstLine.sendkeys('general');
             };
           });
 
-          context("and line on top is first half of split line", function() {
+          context('and line on top is first half of split line', function() {
             before(function() {
               lineNumberAfterFirstCycle = targetLineNumberAfter1stCycleWithNonSplitPageBreaks();
             });
 
-            it("keeps first visible line always on top of viewport", function(done) {
+            it('keeps first visible line always on top of viewport', function(done) {
               // check if viewport is still where it should be after repagination is complete
               utils.testLineIsOnTopOfViewport(targetLineNumber, done);
             });
           });
 
-          context("and line on top is second half of split line", function() {
+          context('and line on top is second half of split line', function() {
             before(function() {
               lineNumberAfterFirstCycle = 1 + targetLineNumberAfter1stCycleWithNonSplitPageBreaks();
             });
 
-            it("keeps first visible line always on top of viewport", function(done) {
+            it('keeps first visible line always on top of viewport', function(done) {
               // top of viewport should have second inner line of target line
               var innerLineNumber = 1;
               utils.testLineIsOnTopOfViewport(targetLineNumber, done, innerLineNumber);
@@ -318,15 +318,15 @@ describe.skip("ep_script_page_view - scroll", function() {
           });
         });
 
-        context("and line is moved bellow a page break", function() {
+        context('and line is moved bellow a page break', function() {
           before(function() {
             editFirstLine = function() {
               var inner$ = helper.padInner$;
 
               // edit first line to make it have three inner lines
-              var longText = utils.buildStringWithLength(60, "1");
-              var $firstLine = inner$("div").first();
-              $firstLine.sendkeys("{selectall}{backspace}");
+              var longText = utils.buildStringWithLength(60, '1');
+              var $firstLine = inner$('div').first();
+              $firstLine.sendkeys('{selectall}{backspace}');
               $firstLine.sendkeys(longText + longText + longText);
             };
 
@@ -337,22 +337,22 @@ describe.skip("ep_script_page_view - scroll", function() {
             }
           });
 
-          context("and line on top is first half of split line", function() {
+          context('and line on top is first half of split line', function() {
             before(function() {
               lineNumberAfterFirstCycle = targetLineNumberAfter1stCycleWithNonSplitPageBreaks();
             });
 
-            it("keeps first visible line always on top of viewport", function(done) {
+            it('keeps first visible line always on top of viewport', function(done) {
               utils.testLineIsOnTopOfViewport(targetLineNumber, done);
             });
           });
 
-          context("and line on top is second half of split line", function() {
+          context('and line on top is second half of split line', function() {
             before(function() {
               lineNumberAfterFirstCycle = 1 + targetLineNumberAfter1stCycleWithNonSplitPageBreaks();
             });
 
-            it("keeps first visible line always on top of viewport", function(done) {
+            it('keeps first visible line always on top of viewport', function(done) {
               // top of viewport should have second inner line of target line
               var innerLineNumber = 1;
               utils.testLineIsOnTopOfViewport(targetLineNumber, done, innerLineNumber);
@@ -362,16 +362,16 @@ describe.skip("ep_script_page_view - scroll", function() {
       });
     });
 
-    context("and caret is visible but is not on line on top of viewport", function() {
+    context('and caret is visible but is not on line on top of viewport', function() {
       before(function() {
         targetLineNumber = lastLineOfPageBeforeLast();
         // as target line is a double-line, keep it that way and use a long text
-        targetLineText = "This very very very very very long line should be on top of viewport";
+        targetLineText = 'This very very very very very long line should be on top of viewport';
         // line with page break above caret was not split yet
         caretLineNumber = targetLineNumber + 1;
       });
 
-      it("keeps line with caret on same position of viewport", function(done) {
+      it('keeps line with caret on same position of viewport', function(done) {
         this.timeout(14000);
 
         // there were some repagination cycles already

--- a/static/tests/frontend/specs/splitElements.js
+++ b/static/tests/frontend/specs/splitElements.js
@@ -1,4 +1,4 @@
-describe.skip("ep_script_page_view - pagination of split elements", function() {
+describe.skip('ep_script_page_view - pagination of split elements', function() {
   // shortcuts for helper functions
   var utils, splitElements;
   // context-dependent values/functions
@@ -12,25 +12,25 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
   beforeEach(function(cb){
     helper.newPad(function() {
       utils.cleanPad(function() {
-        var generals      = utils.buildScriptWithGenerals("general", linesBeforeTargetElement);
+        var generals      = utils.buildScriptWithGenerals('general', linesBeforeTargetElement);
         var targetElement = buildTargetElement();
-        var lastGeneral   = utils.general("last general")
+        var lastGeneral   = utils.general('last general')
         var script        = generals + targetElement + lastGeneral;
 
-        utils.createScriptWith(script, "last general", cb);
+        utils.createScriptWith(script, 'last general', cb);
       });
     });
     this.timeout(60000);
   });
 
-  context("when first line of page is a very long general", function() {
+  context('when first line of page is a very long general', function() {
     before(function() {
       // give enough space for first line of general to fit on first page
       linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-      var line1 = utils.buildStringWithLength(56, "1") + ". "; // need to leave some room on 1st line for one of the tests
-      var line2 = utils.buildStringWithLength(59, "2") + ". ";
-      var line3 = utils.buildStringWithLength(59, "3") + ". ";
-      var line4 = utils.buildStringWithLength(59, "4") + ". ";
+      var line1 = utils.buildStringWithLength(56, '1') + '. '; // need to leave some room on 1st line for one of the tests
+      var line2 = utils.buildStringWithLength(59, '2') + '. ';
+      var line3 = utils.buildStringWithLength(59, '3') + '. ';
+      var line4 = utils.buildStringWithLength(59, '4') + '. ';
       sentences = [line1, line2, line3, line4];
       targetElementText = line1 + line2 + line3 + line4;
       buildTargetElement = function() {
@@ -38,15 +38,15 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       };
     });
 
-    it("splits the original line into two separated lines", function(done) {
+    it('splits the original line into two separated lines', function(done) {
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
       helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
         return $splitElementsWithPageBreaks.length === 1;
       }, 2000).done(function() {
-        var $lines = inner$("div");
+        var $lines = inner$('div');
         var $targetLine = $lines.last().prev();
         var textOnLastDiv = sentences[1] + sentences[2] + sentences[3];
         var textOnDivBeforeLast = sentences[0];
@@ -58,22 +58,22 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    it("merges split line back into a single line when it does not have a pageBreak anymore", function(done) {
+    it('merges split line back into a single line when it does not have a pageBreak anymore', function(done) {
       this.timeout(5000);
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
       helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
         return $splitElementsWithPageBreaks.length === 1;
       }, 2000).done(function() {
         // create another very long general before the last one, so pagination needs to be re-done
-        // (The extra ".prev()" is because we insert a "\n" when line is split between pages)
-        var $threeLinesGeneral = inner$("div").last().prev().prev().prev();
-        var line1 = utils.buildStringWithLength(59, "A") + ". ";
-        var line2 = utils.buildStringWithLength(59, "B") + ". ";
-        var line3 = utils.buildStringWithLength(59, "C") + ". ";
-        $threeLinesGeneral.sendkeys("{selectall}");
+        // (The extra '.prev()' is because we insert a '\n' when line is split between pages)
+        var $threeLinesGeneral = inner$('div').last().prev().prev().prev();
+        var line1 = utils.buildStringWithLength(59, 'A') + '. ';
+        var line2 = utils.buildStringWithLength(59, 'B') + '. ';
+        var line3 = utils.buildStringWithLength(59, 'C') + '. ';
+        $threeLinesGeneral.sendkeys('{selectall}');
         $threeLinesGeneral.sendkeys(line1 + line2 + line3);
 
         // wait for edition to be processed and pagination to be complete
@@ -85,7 +85,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           return utils.cleanText($firstPageBreak.text()) === line3;
         }, 3000).done(function() {
           // now the target line should had been merged back to the original line
-          var $targetLine = inner$("div").last().prev();
+          var $targetLine = inner$('div').last().prev();
           expect(utils.cleanText($targetLine.text())).to.be(targetElementText);
 
           done();
@@ -93,22 +93,22 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    it("removes existing page breaks and recalculates new ones when user changes pad content", function(done) {
+    it('removes existing page breaks and recalculates new ones when user changes pad content', function(done) {
       this.timeout(5000);
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
       helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
         return $splitElementsWithPageBreaks.length === 1;
       }, 2000).done(function() {
         // create another very long general before the last one, so pagination needs to be re-done
-        // (The extra ".prev()" is because we insert a "\n" when line is split between pages)
-        var $threeLinesGeneral = inner$("div").last().prev().prev().prev();
-        var line1 = utils.buildStringWithLength(59, "A") + ". ";
-        var line2 = utils.buildStringWithLength(59, "B") + ". ";
-        var line3 = utils.buildStringWithLength(59, "C") + ". ";
-        $threeLinesGeneral.sendkeys("{selectall}");
+        // (The extra '.prev()' is because we insert a '\n' when line is split between pages)
+        var $threeLinesGeneral = inner$('div').last().prev().prev().prev();
+        var line1 = utils.buildStringWithLength(59, 'A') + '. ';
+        var line2 = utils.buildStringWithLength(59, 'B') + '. ';
+        var line3 = utils.buildStringWithLength(59, 'C') + '. ';
+        $threeLinesGeneral.sendkeys('{selectall}');
         $threeLinesGeneral.sendkeys(line1 + line2 + line3);
 
         // wait for edition to be processed and pagination to be complete
@@ -120,7 +120,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           return utils.cleanText($firstPageBreak.text()) === line3;
         }, 3000).done(function() {
           // now there should be only a single page break (on the first very long general)
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           expect($splitElementsWithPageBreaks.length).to.be(1);
 
           done();
@@ -128,30 +128,30 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    it("merges lines and split them again when user adds text to the end of first half of the split", function(done) {
+    it('merges lines and split them again when user adds text to the end of first half of the split', function(done) {
       this.timeout(6000);
 
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
       helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
         return $splitElementsWithPageBreaks.length === 1;
       }, 2000).done(function() {
         // write something on fist half of split line
-        var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").first();
-        $firstHalfOfSplitLine.sendkeys("{selectall}{rightarrow}");
-        $firstHalfOfSplitLine.sendkeys("something");
+        var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
+        $firstHalfOfSplitLine.sendkeys('{selectall}{rightarrow}');
+        $firstHalfOfSplitLine.sendkeys('something');
 
         var textBeforePageBreak = sentences[0];
-        var textAfterPageBreak = "something" + sentences[1] + sentences[2] + sentences[3];
+        var textAfterPageBreak = 'something' + sentences[1] + sentences[2] + sentences[3];
 
         // wait for pagination to finish
         helper.waitFor(function() {
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").first();
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
           return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
         }, 3000).done(function() {
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").first().next();
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').first().next();
 
           expect(utils.cleanText($secondHalfOfSplitLine.text())).to.be(textAfterPageBreak);
 
@@ -160,31 +160,31 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    it("merges lines and split them again when user adds text to the second half of the split", function(done) {
+    it('merges lines and split them again when user adds text to the second half of the split', function(done) {
       this.timeout(6000);
 
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
       helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
         return $splitElementsWithPageBreaks.length === 1;
       }, 2000).done(function() {
         // write something on second half of split line
-        var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").first().next();
+        var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').first().next();
         // sendkeys fails if we apply it to <div>. Need to apply to the inner span
-        $secondHalfOfSplitLine = $secondHalfOfSplitLine.find("span");
-        $secondHalfOfSplitLine.sendkeys("1. ");
+        $secondHalfOfSplitLine = $secondHalfOfSplitLine.find('span');
+        $secondHalfOfSplitLine.sendkeys('1. ');
 
-        var textBeforePageBreak = sentences[0] + "1. ";
+        var textBeforePageBreak = sentences[0] + '1. ';
         var textAfterPageBreak = sentences[1] + sentences[2] + sentences[3];
 
         // wait for pagination to finish
         helper.waitFor(function() {
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").first();
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
           return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
         }, 3000).done(function() {
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").first().next();
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').first().next();
 
           expect(utils.cleanText($secondHalfOfSplitLine.text())).to.be(textAfterPageBreak);
 
@@ -193,32 +193,32 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    it("merges lines and split them again when user copies & pastes both halves of the split", function(done) {
+    it('merges lines and split them again when user copies & pastes both halves of the split', function(done) {
       this.timeout(6000);
 
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
       helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
         return $splitElementsWithPageBreaks.length === 1;
       }, 2000).done(function() {
-        // "copy" content of split line
-        var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").first();
+        // 'copy' content of split line
+        var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
         var $secondHalfOfSplitLine = $firstHalfOfSplitLine.next();
         var copiedHtml = $firstHalfOfSplitLine[0].outerHTML + $secondHalfOfSplitLine[0].outerHTML;
         var copiedText = utils.cleanText($firstHalfOfSplitLine.text() + $secondHalfOfSplitLine.text());
 
-        // "paste" content of split line on the beginning of pad
-        var $firstLine = inner$("div").first();
+        // 'paste' content of split line on the beginning of pad
+        var $firstLine = inner$('div').first();
         $firstLine.prepend(copiedHtml);
 
         // wait for lines to be processed and page break of 1st line to be removed
         helper.waitFor(function() {
-          var $firstLine = inner$("div").first();
-          return $firstLine.find("splitPageBreak").length === 0;
+          var $firstLine = inner$('div').first();
+          return $firstLine.find('splitPageBreak').length === 0;
         }, 2000).done(function() {
-          var $firstLine = inner$("div").first();
+          var $firstLine = inner$('div').first();
 
           expect(utils.cleanText($firstLine.text())).to.be(copiedText);
 
@@ -227,87 +227,87 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    context("and there is room on previous page for minimum number of lines (1)", function() {
-      it("splits general between the two pages, and first page has one line of the general", function(done) {
+    context('and there is room on previous page for minimum number of lines (1)', function() {
+      it('splits general between the two pages, and first page has one line of the general', function(done) {
         var secondLine = sentences[1];
         utils.testSplitPageBreakIsOn(secondLine, done);
       });
 
-      it("does not add the MORE/CONT'D tags", function(done) {
+      it('does not add the MORE/CONT\'D tags', function(done) {
         utils.testPageBreakDoNotHaveMoreNorContd(done);
       });
     });
 
-    context("and there is room on previous page for more than the minimum line (more than 1)", function() {
+    context('and there is room on previous page for more than the minimum line (more than 1)', function() {
       before(function() {
         // give enough space for first 3 lines of general to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
       });
 
-      it("splits general between the two pages, and first page has as much lines as it can fit", function(done) {
+      it('splits general between the two pages, and first page has as much lines as it can fit', function(done) {
         var targetLine = sentences[3];
         utils.testSplitPageBreakIsOn(targetLine, done);
       });
     });
 
-    context("and there is no room on previous page for any line", function() {
+    context('and there is no room on previous page for any line', function() {
       before(function() {
         // fill the entire page
         linesBeforeTargetElement = GENERALS_PER_PAGE;
       });
 
-      it("moves the entire general for next page", function(done) {
+      it('moves the entire general for next page', function(done) {
         var wholeElement = targetElementText;
         utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
       });
     });
 
-    context("and user presses UNDO", function() {
+    context('and user presses UNDO', function() {
       before(function() {
         // give enough space for a one-line-general + first line of a two-lines-general to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
         buildTargetElement = function() {
-          var generalToBeEdited = utils.general("I'm a general, edit me, please");
+          var generalToBeEdited = utils.general('I am a general, edit me, please');
           var twoLinesGeneral = utils.general(targetElementText);
           return generalToBeEdited + twoLinesGeneral;
         };
       });
 
-      it("disregard changes made by pagination and undoes last edition made by user", function(done) {
+      it('disregard changes made by pagination and undoes last edition made by user', function(done) {
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
           // edit one element
-          var $elementToBeEdited = inner$("div").last().prev().prev();
+          var $elementToBeEdited = inner$('div').last().prev().prev();
           var originalText = $elementToBeEdited.text();
-          $elementToBeEdited.sendkeys("{selectall}");
-          $elementToBeEdited.sendkeys("Now I'm edited!");
+          $elementToBeEdited.sendkeys('{selectall}');
+          $elementToBeEdited.sendkeys('Now I am edited!');
 
           // first UNDO: should revert edition made on previous step
           utils.undo();
-          var $elementToBeEdited = inner$("div").last().prev().prev();
+          var $elementToBeEdited = inner$('div').last().prev().prev();
           expect($elementToBeEdited.text()).to.be(originalText);
 
           // second UNDO: should revert full script creation
           utils.undo();
-          var padText = inner$("#innerdocbody").text();
-          expect(padText).to.be("");
+          var padText = inner$('#innerdocbody').text();
+          expect(padText).to.be('');
 
           done();
         });
       });
     });
 
-    context("and first sentence ends in the middle of last line that fits", function() {
+    context('and first sentence ends in the middle of last line that fits', function() {
       before(function() {
         // give enough space for first sentence (1.5 line long) to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-        var sentence1 = utils.buildStringWithLength(90, "1") + ". "; // 1.5 line long
-        var sentence2 = utils.buildStringWithLength(45, "2") + ". "; // .75 line long
+        var sentence1 = utils.buildStringWithLength(90, '1') + '. '; // 1.5 line long
+        var sentence2 = utils.buildStringWithLength(45, '2') + '. '; // .75 line long
         sentences = [sentence1, sentence2];
         targetElementText = sentence1 + sentence2;
         buildTargetElement = function() {
@@ -315,7 +315,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         };
       });
 
-      it("splits general at the end of first sentence", function(done) {
+      it('splits general at the end of first sentence', function(done) {
         var lastSentence = sentences[1];
         utils.testSplitPageBreakIsOn(lastSentence, done);
       });
@@ -325,13 +325,13 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
     // of the element. For example, if it has two sentences with 75 chars each, the two sentences
     // together need only 3 lines to fit, while if they are split it would need 4 lines to fit them
     // (2 for each sentence)
-    context("and there is another full page after it", function() {
+    context('and there is another full page after it', function() {
       before(function() {
         // build 2 pages, but leave space for 3 extra lines (3 will be used for a 3-lines-long
         // general to be edited on the body of the test, and 1 will be the customized general
         // created by buildTargetElement())
         linesBeforeTargetElement = 2*GENERALS_PER_PAGE - 3;
-        var sentence = "This line should be on third page";
+        var sentence = 'This line should be on third page';
         sentences = [sentence];
         targetElementText = sentence;
         buildTargetElement = function() {
@@ -339,29 +339,29 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         };
       });
 
-      it("considers the height of the resulting second half of the element split", function(done) {
+      it('considers the height of the resulting second half of the element split', function(done) {
         this.timeout(5000);
 
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div nonSplitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div nonSplitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
           // change 57th line to be 3-lines-long (2 sentences, each ~1.25 long, so when they are
           // split they need 2 lines each)
           // build sentences that are ~1.25 line long (when split they need 2 lines each)
-          var sentence1 = utils.buildStringWithLength(75, "1") + ". ";
-          var sentence2 = utils.buildStringWithLength(75, "2") + ". ";
+          var sentence1 = utils.buildStringWithLength(75, '1') + '. ';
+          var sentence2 = utils.buildStringWithLength(75, '2') + '. ';
           // GENERALS_PER_PAGE - 1 === line before last of 1st page
           var $lineAtEndOfFirstPage = utils.getLine(GENERALS_PER_PAGE - 2);
-          $lineAtEndOfFirstPage.sendkeys("{selectall}");
+          $lineAtEndOfFirstPage.sendkeys('{selectall}');
           $lineAtEndOfFirstPage.sendkeys(sentence1 + sentence2);
 
           // wait for edition to be processed and pagination to be complete
           helper.waitFor(function() {
-            var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+            var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
             return $splitElementsWithPageBreaks.length > 0;
           }, 3000).done(function() {
             // 1: verify first page break was added between the two sentences of 57th line
@@ -375,41 +375,41 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    context("and there are whitespaces after last punctuation mark of line that fits on previous page", function() {
+    context('and there are whitespaces after last punctuation mark of line that fits on previous page', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var sentence1 = utils.buildStringWithLength(45, "1") + ".     ";
-        var sentence2 = utils.buildStringWithLength(45, "2") + ". ";
+        var sentence1 = utils.buildStringWithLength(45, '1') + '.     ';
+        var sentence2 = utils.buildStringWithLength(45, '2') + '. ';
         sentences = [sentence1, sentence2];
-        targetElementText = sentences.join("");
+        targetElementText = sentences.join('');
       });
 
-      it("leaves whitespaces on previous page", function(done) {
+      it('leaves whitespaces on previous page', function(done) {
         var lastSentence = sentences[1];
         utils.testSplitPageBreakIsOn(lastSentence, done);
       });
     });
 
-    context("and there are whitespaces but no punctuation mark on line that fits on previous page", function() {
+    context('and there are whitespaces but no punctuation mark on line that fits on previous page', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var sentence1 = utils.buildStringWithLength(55, "1") + " 1 ";
-        var sentence2 = utils.buildStringWithLength(58, "2");
+        var sentence1 = utils.buildStringWithLength(55, '1') + ' 1 ';
+        var sentence2 = utils.buildStringWithLength(58, '2');
         sentences = [sentence1, sentence2];
-        targetElementText = sentences.join("");
+        targetElementText = sentences.join('');
       });
 
-      it("splits line by whitespace", function(done) {
+      it('splits line by whitespace', function(done) {
         var lastSentence = sentences[1];
         utils.testSplitPageBreakIsOn(lastSentence, done);
       });
     });
 
-    context("and there are no whitespaces nor punctuation marks on line that fits on previous page", function() {
+    context('and there are no whitespaces nor punctuation marks on line that fits on previous page', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var sentence1 = utils.buildStringWithLength(61, "1");
-        var sentence2 = "2";
+        var sentence1 = utils.buildStringWithLength(61, '1');
+        var sentence2 = '2';
         sentences = [sentence1, sentence2];
         targetElementText = sentence1 + sentence2;
         buildTargetElement = function() {
@@ -417,21 +417,21 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         };
       });
 
-      it("forces general to be split at the end of first line", function(done) {
+      it('forces general to be split at the end of first line', function(done) {
         var lastSentence = sentences[1];
         utils.testSplitPageBreakIsOn(lastSentence, done);
       });
     });
 
-    context("and user keeps editing pad text after the split line", function() {
+    context('and user keeps editing pad text after the split line', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var line1 = utils.buildStringWithLength(59, "1") + ". ";
-        var line2 = utils.buildStringWithLength(59, "2") + ". ";
-        var line3 = utils.buildStringWithLength(59, "3") + ". ";
-        var line4 = utils.buildStringWithLength(59, "4") + ". ";
-        var line5 = utils.buildStringWithLength(59, "5") + ". ";
-        var line6 = utils.buildStringWithLength(59, "6") + ". ";
+        var line1 = utils.buildStringWithLength(59, '1') + '. ';
+        var line2 = utils.buildStringWithLength(59, '2') + '. ';
+        var line3 = utils.buildStringWithLength(59, '3') + '. ';
+        var line4 = utils.buildStringWithLength(59, '4') + '. ';
+        var line5 = utils.buildStringWithLength(59, '5') + '. ';
+        var line6 = utils.buildStringWithLength(59, '6') + '. ';
         sentences = [line1, line2, line3, line4, line5, line6];
         targetElementText = line1 + line2 + line3 + line4 + line5 + line6;
         buildTargetElement = function() {
@@ -439,14 +439,14 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         };
       });
 
-      it("merges lines and split them again on each edition", function(done) {
+      it('merges lines and split them again on each edition', function(done) {
         this.timeout(10000);
 
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
           // repeat some times: remove one line then check is pagination is correct
@@ -465,10 +465,10 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    context("and user removes part of lines split between pages", function() {
+    context('and user removes part of lines split between pages', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var line1 = "last general";
+        var line1 = 'last general';
         sentences = [line1];
         targetElementText = line1;
         buildTargetElement = function() {
@@ -476,31 +476,31 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         };
       });
 
-      it("does not merge lines on pagination if both halves removed are from the same split", function(done) {
+      it('does not merge lines on pagination if both halves removed are from the same split', function(done) {
         this.timeout(6000);
 
         var inner$ = helper.padInner$;
 
-        var veryLongLine = utils.buildStringWithLength(59, ".") + " ";
+        var veryLongLine = utils.buildStringWithLength(59, '.') + ' ';
 
-        var line1 = utils.buildStringWithLength(59, "1") + ". ";
-        var line2 = utils.buildStringWithLength(59, "2") + ". ";
-        var line3 = utils.buildStringWithLength(59, "3") + ". ";
-        var line4 = utils.buildStringWithLength(59, "4") + ". ";
+        var line1 = utils.buildStringWithLength(59, '1') + '. ';
+        var line2 = utils.buildStringWithLength(59, '2') + '. ';
+        var line3 = utils.buildStringWithLength(59, '3') + '. ';
+        var line4 = utils.buildStringWithLength(59, '4') + '. ';
         var multiLineText = line1 + line2 + line3 + line4;
 
-        var $targetLine = inner$("div").last().prev().prev();
+        var $targetLine = inner$('div').last().prev().prev();
         $targetLine.sendkeys('{selectall}').sendkeys('not ' + multiLineText + veryLongLine);
 
         // wait for pagination to finish
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
           // Select part of 1st and 2nd halves of same split to be able to remove them at the same time.
-          var $firstHalfOfSplitLine  = inner$("div:has(splitPageBreak)");
+          var $firstHalfOfSplitLine  = inner$('div:has(splitPageBreak)');
           var $secondHalfOfSplitLine = $firstHalfOfSplitLine.next();
-          var startOffset            = "not ".length - 1;
+          var startOffset            = 'not '.length - 1;
           var endOffset              = line2.length + line3.length + line4.length;
 
           // remove all selected content (part of 1st half + entire 2nd half of same split)
@@ -509,16 +509,16 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
           // wait for pagination to finish (content is removed, lines merged, etc.)
           helper.waitFor(function() {
-            var $nonSplitElementsWithPageBreaks = inner$("div nonSplitPageBreak");
+            var $nonSplitElementsWithPageBreaks = inner$('div nonSplitPageBreak');
             return $nonSplitElementsWithPageBreaks.length === 1;
           }, 2000).done(function() {
-            var $lines = inner$("div");
+            var $lines = inner$('div');
             var $targetLine = $lines.last().prev();
             var $lineBeforeTarget = $targetLine.prev();
 
-            // last two lines should be "not.....(...)" and "last general"
-            expect($targetLine.text()).to.be("last general");
-            expect(utils.cleanText($lineBeforeTarget.text())).to.be("not" + veryLongLine);
+            // last two lines should be 'not.....(...)' and 'last general'
+            expect($targetLine.text()).to.be('last general');
+            expect(utils.cleanText($lineBeforeTarget.text())).to.be('not' + veryLongLine);
 
             done();
           });
@@ -526,14 +526,14 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    context("and caret is at the end of 1st half of split line, and user presses DELETE", function() {
+    context('and caret is at the end of 1st half of split line, and user presses DELETE', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
         // lines start and end with letters to make it easier to see errors if any test fails
-        var line1 = "AA" + utils.buildStringWithLength(55, "1") + "ZZ. ";
-        var line2 = "AA" + utils.buildStringWithLength(55, "2") + "ZZ. ";
-        var line3 = "AA" + utils.buildStringWithLength(55, "3") + "ZZ. ";
-        var line4 = "AA" + utils.buildStringWithLength(55, "4") + "ZZ. ";
+        var line1 = 'AA' + utils.buildStringWithLength(55, '1') + 'ZZ. ';
+        var line2 = 'AA' + utils.buildStringWithLength(55, '2') + 'ZZ. ';
+        var line3 = 'AA' + utils.buildStringWithLength(55, '3') + 'ZZ. ';
+        var line4 = 'AA' + utils.buildStringWithLength(55, '4') + 'ZZ. ';
         sentences = [line1, line2, line3, line4];
         targetElementText = line1 + line2 + line3 + line4;
         buildTargetElement = function() {
@@ -546,14 +546,14 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         // there should be a page break before we start testing
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
           utils.placeCaretAtTheEndOfLine(GENERALS_PER_PAGE-1, done);
         });
       });
 
-      it("merges lines and removes first char of 2nd half", function(done) {
+      it('merges lines and removes first char of 2nd half', function(done) {
         this.timeout(6000);
 
         var inner$ = helper.padInner$;
@@ -566,10 +566,10 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         // wait for pagination to finish
         helper.waitFor(function() {
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").first().next();
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').first().next();
           return utils.cleanText($secondHalfOfSplitLine.text()) === textAfterPageBreak;
         }, 3000).done(function() {
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").first();
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
 
           expect(utils.cleanText($firstHalfOfSplitLine.text())).to.be(textBeforePageBreak);
 
@@ -578,14 +578,14 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    context("and caret is at the beginning of 2nd half of split line, and user presses BACKSPACE", function() {
+    context('and caret is at the beginning of 2nd half of split line, and user presses BACKSPACE', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
         // lines start and end with letters to make it easier to see errors if any test fails
-        var line1 = "AA" + utils.buildStringWithLength(55, "1") + "ZZ. ";
-        var line2 = "AA" + utils.buildStringWithLength(55, "2") + "ZZ. ";
-        var line3 = "AA" + utils.buildStringWithLength(55, "3") + "ZZ. ";
-        var line4 = "AA" + utils.buildStringWithLength(55, "4") + "ZZ. ";
+        var line1 = 'AA' + utils.buildStringWithLength(55, '1') + 'ZZ. ';
+        var line2 = 'AA' + utils.buildStringWithLength(55, '2') + 'ZZ. ';
+        var line3 = 'AA' + utils.buildStringWithLength(55, '3') + 'ZZ. ';
+        var line4 = 'AA' + utils.buildStringWithLength(55, '4') + 'ZZ. ';
         sentences = [line1, line2, line3, line4];
         targetElementText = line1 + line2 + line3 + line4;
         buildTargetElement = function() {
@@ -598,14 +598,14 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         // there should be a page break before we start testing
         helper.waitFor(function() {
-          var $pageBreaks = inner$("div splitPageBreak");
+          var $pageBreaks = inner$('div splitPageBreak');
           return $pageBreaks.length === 1;
         }, 2000).done(function() {
           utils.placeCaretInTheBeginningOfLine(GENERALS_PER_PAGE, done);
         });
       });
 
-      it("merges lines and removes last char of 1st half", function(done) {
+      it('merges lines and removes last char of 1st half', function(done) {
         this.timeout(6000);
 
         var inner$ = helper.padInner$;
@@ -622,7 +622,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         // wait for pagination to finish
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div:has(splitPageBreak)");
+          var $splitElementsWithPageBreaks = inner$('div:has(splitPageBreak)');
 
           return ($splitElementsWithPageBreaks.length === 1) &&
                  (utils.cleanText($splitElementsWithPageBreaks.text()) === expectedTextOnFirstHalf);
@@ -636,15 +636,15 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
     });
 
-    context("and pad has multiple split lines", function() {
+    context('and pad has multiple split lines', function() {
       before(function() {
         linesBeforeTargetElement = 3*GENERALS_PER_PAGE - 3;
-        var line1 = utils.buildStringWithLength(56, "1") + ". ";
-        var line2 = utils.buildStringWithLength(56, "2") + ". ";
-        var line3 = utils.buildStringWithLength(56, "3") + ". ";
-        var line4 = utils.buildStringWithLength(56, "4") + ". ";
+        var line1 = utils.buildStringWithLength(56, '1') + '. ';
+        var line2 = utils.buildStringWithLength(56, '2') + '. ';
+        var line3 = utils.buildStringWithLength(56, '3') + '. ';
+        var line4 = utils.buildStringWithLength(56, '4') + '. ';
         sentences = [line1, line2, line3, line4];
-        targetElementText = "the end of the pad";
+        targetElementText = 'the end of the pad';
         buildTargetElement = function() {
           return utils.general(line1 + line2 + line3 + line4) + utils.general(targetElementText);
         };
@@ -655,64 +655,64 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         var inner$ = helper.padInner$;
 
-        var line1 = utils.buildStringWithLength(59, "X") + ". ";
-        var line2 = utils.buildStringWithLength(59, "Y") + ". ";
+        var line1 = utils.buildStringWithLength(59, 'X') + '. ';
+        var line2 = utils.buildStringWithLength(59, 'Y') + '. ';
         var veryLongLine = line1 + line2;
 
         // there should be a page break before we start creating other split page breaks
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
           // create some other split page breaks before the existing one
           var $lastLineOfSecondPage = utils.getLine(2*GENERALS_PER_PAGE-2);
-          $lastLineOfSecondPage.sendkeys("{selectall}");
+          $lastLineOfSecondPage.sendkeys('{selectall}');
           $lastLineOfSecondPage.sendkeys(veryLongLine);
 
           var $lastLineOfFirstPage = utils.getLine(GENERALS_PER_PAGE-1);
-          $lastLineOfFirstPage.sendkeys("{selectall}");
+          $lastLineOfFirstPage.sendkeys('{selectall}');
           $lastLineOfFirstPage.sendkeys(veryLongLine);
 
           // there should be 3 page breaks now
           helper.waitFor(function() {
-            var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+            var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
             return $splitElementsWithPageBreaks.length === 3;
           }, 2000).done(done);
         });
       });
 
-      context("and user adds text before any split line", function() {
+      context('and user adds text before any split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist line
-          var $firstLine = inner$("div").first();
-          $firstLine.sendkeys("{selectall}");
-          $firstLine.sendkeys("AAAAAAAAA");
+          var $firstLine = inner$('div').first();
+          $firstLine.sendkeys('{selectall}');
+          $firstLine.sendkeys('AAAAAAAAA');
 
           done();
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var firstLine = function() { return helper.padInner$("div").first() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var firstLine = function() { return helper.padInner$('div').first() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(firstLine, textAfterInsertedText, false, done);
         });
       });
 
-      context("and user adds text after all split lines", function() {
+      context('and user adds text after all split lines', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on target line
-          var $targetLine = inner$("div").last().prev();
-          $targetLine.sendkeys("{selectall}{leftarrow}");
-          $targetLine.sendkeys("AAAAAAAAA");
+          var $targetLine = inner$('div').last().prev();
+          $targetLine.sendkeys('{selectall}{leftarrow}');
+          $targetLine.sendkeys('AAAAAAAAA');
 
           // wait for changes to be processed and pagination to finish
           // Note: as {enter} cannot be used on sendkeys between chars (for some reason we don't
@@ -721,62 +721,62 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           setTimeout(done, 2000);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var targetLine = function() { return helper.padInner$("div").last().prev() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var targetLine = function() { return helper.padInner$('div').last().prev() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(targetLine, textAfterInsertedText, true, done);
         });
       });
 
-      context("and user adds text before the end of 1st half of split line", function() {
+      context('and user adds text before the end of 1st half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist half of last split line
-          // ("1. " will be added to 1st half; "AAAAAAAAA " to the 2nd)
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
-          $firstHalfOfSplitLine.sendkeys("{selectall}{rightarrow}{leftarrow}{leftarrow}");
-          $firstHalfOfSplitLine.sendkeys("1. AAAAAAAAA");
+          // ('1. ' will be added to 1st half; 'AAAAAAAAA ' to the 2nd)
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
+          $firstHalfOfSplitLine.sendkeys('{selectall}{rightarrow}{leftarrow}{leftarrow}');
+          $firstHalfOfSplitLine.sendkeys('1. AAAAAAAAA');
 
-          var textBeforePageBreak = "1" + sentences[0];
+          var textBeforePageBreak = '1' + sentences[0];
 
           // wait for pagination to finish
           helper.waitFor(function() {
-            var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+            var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
             return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var secondHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last().next() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
         });
       });
 
-      context("and user adds text to the end of 1st half of split line", function() {
+      context('and user adds text to the end of 1st half of split line', function() {
         var theText;
 
         beforeEach(function(done) {
           var inner$ = helper.padInner$;
 
           // write something on fist half of last split line
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
-          $firstHalfOfSplitLine.sendkeys("{selectall}{rightarrow}");
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
+          $firstHalfOfSplitLine.sendkeys('{selectall}{rightarrow}');
           $firstHalfOfSplitLine.sendkeys(theText);
 
           done();
         });
 
-        context("and text inserted is short", function() {
+        context('and text inserted is short', function() {
           var textBeforePageBreak;
 
           before(function() {
-            theText = "0. ";
+            theText = '0. ';
             textBeforePageBreak = sentences[0] + theText;
           });
 
@@ -786,7 +786,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
             var inner$ = helper.padInner$;
 
             helper.waitFor(function() {
-              var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+              var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
               return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
             }, 3000).done(function() {
               // there's no way to check if pagination was done or not. We need to force a timeout here
@@ -794,17 +794,17 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
             });
           });
 
-          it("keeps caret at the end of inserted text", function(done) {
-            var firstHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last() };
+          it('keeps caret at the end of inserted text', function(done) {
+            var firstHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last() };
             var textAfterInsertedText = textBeforePageBreak.length;
 
             splitElements.testCaretIsOn(firstHalfOfSplitLine, textAfterInsertedText, false, done);
           });
         });
 
-        context("and text inserted is long", function() {
+        context('and text inserted is long', function() {
           before(function() {
-            theText = "something";
+            theText = 'something';
           });
 
           beforeEach(function(done) {
@@ -816,13 +816,13 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
             // wait for pagination to finish
             helper.waitFor(function() {
-              var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+              var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
               return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
             }, 3000).done(done);
           });
 
-          it("keeps caret at the end of inserted text", function(done) {
-            var secondHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last().next() };
+          it('keeps caret at the end of inserted text', function(done) {
+            var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
             var textAfterInsertedText = theText.length;
 
             splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
@@ -830,57 +830,57 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         });
       });
 
-      context("and user adds text to the end of 2nd half of split line", function() {
+      context('and user adds text to the end of 2nd half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist half of last split line
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").last().next();
-          $secondHalfOfSplitLine.sendkeys("{selectall}{rightarrow}");
-          $secondHalfOfSplitLine.sendkeys("something{enter}else");
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').last().next();
+          $secondHalfOfSplitLine.sendkeys('{selectall}{rightarrow}');
+          $secondHalfOfSplitLine.sendkeys('something{enter}else');
 
           // wait for changes to be processed and pagination to finish
           helper.waitFor(function() {
-            var $lineAfterPageBreak = inner$("div:has(splitPageBreak)").last().next().next();
-            return $lineAfterPageBreak.text() === "else";
+            var $lineAfterPageBreak = inner$('div:has(splitPageBreak)').last().next().next();
+            return $lineAfterPageBreak.text() === 'else';
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var lineAfterPageBreak = function() { return helper.padInner$("div:has(splitPageBreak)").last().next().next() };
+        it('keeps caret at the end of inserted text', function(done) {
+          var lineAfterPageBreak = function() { return helper.padInner$('div:has(splitPageBreak)').last().next().next() };
           var textAfterInsertedText = lineAfterPageBreak().text().length;
 
           splitElements.testCaretIsOn(lineAfterPageBreak, textAfterInsertedText, true, done);
         });
       });
 
-      context("and user adds text to the beginning of 2nd half of split line", function() {
+      context('and user adds text to the beginning of 2nd half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on second half of last split line
-          // ("1. " will be moved to 1st half; "AAAAAAAAA" to the 2nd)
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").last().next();
+          // ('1. ' will be moved to 1st half; 'AAAAAAAAA' to the 2nd)
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').last().next();
           // sendkeys fails if we apply it to <div>. Need to apply to the inner span
-          $secondHalfOfSplitLine = $secondHalfOfSplitLine.find("span");
-          $secondHalfOfSplitLine.sendkeys("{selectall}{leftarrow}");
-          $secondHalfOfSplitLine.sendkeys("1. AAAAAAAAA");
+          $secondHalfOfSplitLine = $secondHalfOfSplitLine.find('span');
+          $secondHalfOfSplitLine.sendkeys('{selectall}{leftarrow}');
+          $secondHalfOfSplitLine.sendkeys('1. AAAAAAAAA');
 
-          var textBeforePageBreak = sentences[0] + "1. ";
+          var textBeforePageBreak = sentences[0] + '1. ';
           // wait for pagination to finish
           helper.waitFor(function() {
-            var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+            var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
             return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var secondHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last().next() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
         });
@@ -888,58 +888,58 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
     });
   });
 
-  context("when first line of page is a very long action", function() {
+  context('when first line of page is a very long action', function() {
     before(function() {
       buildTargetElement = function() {
         return utils.action(targetElementText);
       };
     });
 
-    context("and there is no room on previous page for minimum number of lines (2)", function() {
+    context('and there is no room on previous page for minimum number of lines (2)', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-        var line1 = utils.buildStringWithLength(59, "1") + ". ";
-        var line2 = utils.buildStringWithLength(59, "2") + ". ";
-        var line3 = utils.buildStringWithLength(59, "3") + ". ";
-        var line4 = utils.buildStringWithLength(59, "4") + ". ";
+        var line1 = utils.buildStringWithLength(59, '1') + '. ';
+        var line2 = utils.buildStringWithLength(59, '2') + '. ';
+        var line3 = utils.buildStringWithLength(59, '3') + '. ';
+        var line4 = utils.buildStringWithLength(59, '4') + '. ';
         sentences = [line1, line2, line3, line4];
         targetElementText = line1 + line2 + line3 + line4;
       });
 
-      it("moves the entire action for next page", function(done) {
+      it('moves the entire action for next page', function(done) {
         var wholeElement = targetElementText;
         utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
       });
     });
 
-    context("and there is room on previous page for minimum number of lines (2)", function() {
+    context('and there is room on previous page for minimum number of lines (2)', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
         // build sentences that are ~1.25 line long (when split they need 2 lines each)
-        var line1 = utils.buildStringWithLength(75, "1") + ". ";
-        var line2 = utils.buildStringWithLength(75, "2") + ". ";
+        var line1 = utils.buildStringWithLength(75, '1') + '. ';
+        var line2 = utils.buildStringWithLength(75, '2') + '. ';
         sentences = [line1, line2];
         targetElementText = line1 + line2;
       });
 
-      it("splits action between the two pages, and first page has two lines of the action", function(done) {
+      it('splits action between the two pages, and first page has two lines of the action', function(done) {
         var newThirdLine = sentences[1];
         utils.testSplitPageBreakIsOn(newThirdLine, done);
       });
 
-      it("keeps the two halves of the line as actions", function(done) {
+      it('keeps the two halves of the line as actions', function(done) {
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
         helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
           return $splitElementsWithPageBreaks.length === 1;
         }, 2000).done(function() {
-          var $secondHalfOfAction = inner$("div").last().prev();
+          var $secondHalfOfAction = inner$('div').last().prev();
           var $firstHalfOfAction = $secondHalfOfAction.prev();
 
-          var secondHalfIsAnAction = $secondHalfOfAction.find("action").length > 0;
-          var firstHalfIsAnAction = $firstHalfOfAction.find("action").length > 0;
+          var secondHalfIsAnAction = $secondHalfOfAction.find('action').length > 0;
+          var firstHalfIsAnAction = $firstHalfOfAction.find('action').length > 0;
 
           expect(firstHalfIsAnAction).to.be(true);
           expect(secondHalfIsAnAction).to.be(true);
@@ -948,120 +948,120 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         });
       });
 
-      it("does not add the MORE/CONT'D tags", function(done) {
+      it('does not add the MORE/CONT\'D tags', function(done) {
         utils.testPageBreakDoNotHaveMoreNorContd(done);
       });
 
-      context("and user edits last line of previous page", function() {
-        it("merges the split line and paginate again", function(done) {
+      context('and user edits last line of previous page', function() {
+        it('merges the split line and paginate again', function(done) {
           this.timeout(6000);
           var inner$ = helper.padInner$;
 
           // there should be a page break before we start testing
           helper.waitFor(function() {
-            var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+            var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
             return $splitElementsWithPageBreaks.length === 1;
           }, 2000).done(function() {
             // edit last line of previous page
-            var $lastLineOfFirstPage = inner$("div").last().prev().prev();
-            $lastLineOfFirstPage.sendkeys("{selectall}{rightarrow}");
-            $lastLineOfFirstPage.sendkeys("something");
+            var $lastLineOfFirstPage = inner$('div').last().prev().prev();
+            $lastLineOfFirstPage.sendkeys('{selectall}{rightarrow}');
+            $lastLineOfFirstPage.sendkeys('something');
 
             // new content should be moved to next page
-            var newTargetLine = "something" + sentences[1];
+            var newTargetLine = 'something' + sentences[1];
             helper.waitFor(function() {
-              var $targetLine = inner$("div").last().prev();
+              var $targetLine = inner$('div').last().prev();
               return utils.cleanText($targetLine.text()) === newTargetLine;
             }, 2000).done(done);
           });
         });
       });
 
-      context("but next page will have less then the minimum lines (2) of an action", function() {
+      context('but next page will have less then the minimum lines (2) of an action', function() {
         before(function() {
-          var line1 = utils.buildStringWithLength(59, "1") + ". ";
-          var line2 = utils.buildStringWithLength(59, "2") + ". ";
-          var line3 = utils.buildStringWithLength(59, "3") + ". ";
+          var line1 = utils.buildStringWithLength(59, '1') + '. ';
+          var line2 = utils.buildStringWithLength(59, '2') + '. ';
+          var line3 = utils.buildStringWithLength(59, '3') + '. ';
           sentences = [line1, line2, line3];
           targetElementText = line1 + line2 + line3;
         });
 
-        it("moves the entire action for next page", function(done) {
+        it('moves the entire action for next page', function(done) {
           var wholeElement = targetElementText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
         });
       });
 
-      context("but previous page will have less then the minimum lines (2) of an action", function() {
+      context('but previous page will have less then the minimum lines (2) of an action', function() {
         before(function() {
-          var line1 = utils.buildStringWithLength(59, "1") + ". ";
-          var line2 = utils.buildStringWithLength(59, "2");
-          var line3 = utils.buildStringWithLength(59, "3");
+          var line1 = utils.buildStringWithLength(59, '1') + '. ';
+          var line2 = utils.buildStringWithLength(59, '2');
+          var line3 = utils.buildStringWithLength(59, '3');
           sentences = [line1, line2, line3];
           targetElementText = line1 + line2 + line3;
         });
 
-        it("moves the entire action for next page", function(done) {
+        it('moves the entire action for next page', function(done) {
           var wholeElement = targetElementText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
         });
       });
     });
 
-    context("and there is room on previous page for more than the minimum line (+2)", function() {
+    context('and there is room on previous page for more than the minimum line (+2)', function() {
       before(function() {
         // give enough space for first 3 lines of action to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
-        var line1 = utils.buildStringWithLength(59, "1") + ". ";
-        var line2 = utils.buildStringWithLength(59, "2") + ". ";
-        var line3 = utils.buildStringWithLength(59, "3") + ". ";
-        var line4 = utils.buildStringWithLength(59, "4") + ". ";
-        var line5 = utils.buildStringWithLength(59, "5") + ". ";
-        var line6 = utils.buildStringWithLength(59, "6") + ". ";
+        var line1 = utils.buildStringWithLength(59, '1') + '. ';
+        var line2 = utils.buildStringWithLength(59, '2') + '. ';
+        var line3 = utils.buildStringWithLength(59, '3') + '. ';
+        var line4 = utils.buildStringWithLength(59, '4') + '. ';
+        var line5 = utils.buildStringWithLength(59, '5') + '. ';
+        var line6 = utils.buildStringWithLength(59, '6') + '. ';
         sentences = [line1, line2, line3, line4, line5, line6];
         targetElementText = line1 + line2 + line3 + line4 + line5 + line6;
       });
 
-      it("splits action between the two pages, and first page has as much lines as it can fit", function(done) {
+      it('splits action between the two pages, and first page has as much lines as it can fit', function(done) {
         var targetLine = sentences[3];
         utils.testSplitPageBreakIsOn(targetLine, done);
       });
 
-      context("but next page will have less then the minimum lines (2) of an action", function() {
+      context('but next page will have less then the minimum lines (2) of an action', function() {
         before(function() {
           // give enough space for first 5 lines of action to fit on first page (which would leave
           // only one line on next page)
           linesBeforeTargetElement = GENERALS_PER_PAGE - 6;
         });
 
-        it("splits action between the two pages, and second page keep the minimum lines it needs", function(done) {
+        it('splits action between the two pages, and second page keep the minimum lines it needs', function(done) {
           var targetLine = sentences[4];
           utils.testSplitPageBreakIsOn(targetLine, done);
         });
       });
     });
 
-    context("and there are no whitespaces nor punctuation marks on lines that fits on previous page", function() {
+    context('and there are no whitespaces nor punctuation marks on lines that fits on previous page', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
-        var line1 = utils.buildStringWithLength(61, "1");
-        var line2 = utils.buildStringWithLength(61, "2");
-        var line3 = utils.buildStringWithLength(61, "3");
-        var line4 = utils.buildStringWithLength(61, "4");
+        var line1 = utils.buildStringWithLength(61, '1');
+        var line2 = utils.buildStringWithLength(61, '2');
+        var line3 = utils.buildStringWithLength(61, '3');
+        var line4 = utils.buildStringWithLength(61, '4');
         sentences = [line1, line2, line3];
-        targetElementText = sentences.join("");
+        targetElementText = sentences.join('');
         buildTargetElement = function() {
           return utils.action(targetElementText);
         };
       });
 
-      it("moves the entire action for next page", function(done) {
+      it('moves the entire action for next page', function(done) {
         var wholeElement = targetElementText;
         utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
       });
     });
 
-    context("and pad has multiple split lines", function() {
+    context('and pad has multiple split lines', function() {
       // (generals to fill the page) +
       // (1st half of split action (2 lines of text + 1 of top margin))
       var LINES_ON_PAGE_1 = (GENERALS_PER_PAGE - 4) + (1);
@@ -1079,12 +1079,12 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
       before(function() {
         linesBeforeTargetElement = LAST_LINE_OF_PAGE_2 + LINES_ON_PAGE_3;
-        var line1 = utils.buildStringWithLength(57, "1") + ". ";
-        var line2 = utils.buildStringWithLength(57, "2") + ". ";
-        var line3 = utils.buildStringWithLength(57, "3") + ". ";
-        var line4 = utils.buildStringWithLength(57, "4") + ". ";
+        var line1 = utils.buildStringWithLength(57, '1') + '. ';
+        var line2 = utils.buildStringWithLength(57, '2') + '. ';
+        var line3 = utils.buildStringWithLength(57, '3') + '. ';
+        var line4 = utils.buildStringWithLength(57, '4') + '. ';
         sentences = [line1, line2, line3, line4];
-        targetElementText = "the end of the pad";
+        targetElementText = 'the end of the pad';
         buildTargetElement = function() {
           return utils.action(line1 + line2 + line3 + line4) + utils.general(targetElementText);
         };
@@ -1096,19 +1096,19 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         var smUtils = ep_script_scene_marks_test_helper.utils;
         var inner$ = helper.padInner$;
 
-        var line1 = utils.buildStringWithLength(59, "W") + ". ";
-        var line2 = utils.buildStringWithLength(59, "X") + ". ";
-        var line3 = utils.buildStringWithLength(59, "Y") + ". ";
-        var line4 = utils.buildStringWithLength(59, "Z") + ". ";
+        var line1 = utils.buildStringWithLength(59, 'W') + '. ';
+        var line2 = utils.buildStringWithLength(59, 'X') + '. ';
+        var line3 = utils.buildStringWithLength(59, 'Y') + '. ';
+        var line4 = utils.buildStringWithLength(59, 'Z') + '. ';
         var veryLongLine = line1 + line2 + line3 + line4;
 
         // create some other actions with split page breaks before the existing one
         var $lastLineOfFirstPage = utils.getLine(LAST_LINE_OF_PAGE_1);
-        $lastLineOfFirstPage.sendkeys("{selectall}");
+        $lastLineOfFirstPage.sendkeys('{selectall}');
         $lastLineOfFirstPage.sendkeys(veryLongLine);
 
         var $lastLineOfSecondPage = utils.getLine(LAST_LINE_OF_PAGE_2);
-        $lastLineOfSecondPage.sendkeys("{selectall}");
+        $lastLineOfSecondPage.sendkeys('{selectall}');
         $lastLineOfSecondPage.sendkeys(veryLongLine);
 
         // change both lines to action
@@ -1116,169 +1116,169 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           smUtils.changeLineToElement(utils.ACTION, LAST_LINE_OF_PAGE_1, function() {
             // there should be 3 page breaks now
             helper.waitFor(function() {
-              var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
+              var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
               return $splitElementsWithPageBreaks.length === 3;
             }, 2000).done(done);
           });
         });
       });
 
-      context("and user adds text before any split line", function() {
+      context('and user adds text before any split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist line
-          var $firstLine = inner$("div").first();
-          $firstLine.sendkeys("{selectall}");
-          $firstLine.sendkeys("AAAAAAAAA");
+          var $firstLine = inner$('div').first();
+          $firstLine.sendkeys('{selectall}');
+          $firstLine.sendkeys('AAAAAAAAA');
 
           done();
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var firstLine = function() { return helper.padInner$("div").first() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var firstLine = function() { return helper.padInner$('div').first() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(firstLine, textAfterInsertedText, false, done);
         });
       });
 
-      context("and user adds text after all split lines", function() {
+      context('and user adds text after all split lines', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on target line
-          var $targetLine = inner$("div").last().prev();
-          $targetLine.sendkeys("{selectall}{leftarrow}");
-          $targetLine.sendkeys("AAAAAAAAA{enter}BBBBBBBBBBBB");
+          var $targetLine = inner$('div').last().prev();
+          $targetLine.sendkeys('{selectall}{leftarrow}');
+          $targetLine.sendkeys('AAAAAAAAA{enter}BBBBBBBBBBBB');
 
           // wait for changes to be processed and pagination to finish
           helper.waitFor(function() {
-            var $targetLine = inner$("div").last().prev();
-            return $targetLine.text() === "BBBBBBBBBBBB" + targetElementText;
+            var $targetLine = inner$('div').last().prev();
+            return $targetLine.text() === 'BBBBBBBBBBBB' + targetElementText;
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var targetLine = function() { return helper.padInner$("div").last().prev() };
-          var textAfterInsertedText = "BBBBBBBBBBBB".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var targetLine = function() { return helper.padInner$('div').last().prev() };
+          var textAfterInsertedText = 'BBBBBBBBBBBB'.length;
 
           splitElements.testCaretIsOn(targetLine, textAfterInsertedText, true, done);
         });
       });
 
-      context("and user adds text before the end of 1st half of split line", function() {
+      context('and user adds text before the end of 1st half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist half of last split line
-          // ("2." will be added to 1st half; "AAAAAAAAA " to the 2nd)
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
-          $firstHalfOfSplitLine.sendkeys("{selectall}{rightarrow}{leftarrow}{leftarrow}");
-          $firstHalfOfSplitLine.sendkeys("2. AAAAAAAAA");
+          // ('2.' will be added to 1st half; 'AAAAAAAAA ' to the 2nd)
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
+          $firstHalfOfSplitLine.sendkeys('{selectall}{rightarrow}{leftarrow}{leftarrow}');
+          $firstHalfOfSplitLine.sendkeys('2. AAAAAAAAA');
 
-          var textBeforePageBreak = sentences[0] + "2" + sentences[1];
+          var textBeforePageBreak = sentences[0] + '2' + sentences[1];
 
           // wait for pagination to finish
           helper.waitFor(function() {
-            var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+            var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
             return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var secondHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last().next() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
         });
       });
 
-      context("and user adds text to the end of 1st half of split line", function() {
+      context('and user adds text to the end of 1st half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist half of last split line
-          var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
-          $firstHalfOfSplitLine.sendkeys("{selectall}{rightarrow}");
-          $firstHalfOfSplitLine.sendkeys("something");
+          var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
+          $firstHalfOfSplitLine.sendkeys('{selectall}{rightarrow}');
+          $firstHalfOfSplitLine.sendkeys('something');
 
           var textBeforePageBreak = sentences[0] + sentences[1];
 
           // wait for pagination to finish
           helper.waitFor(function() {
-            var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+            var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
             return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var secondHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last().next() };
-          var textAfterInsertedText = "something".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
+          var textAfterInsertedText = 'something'.length;
 
           splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
         });
       });
 
-      context("and user adds text to the end of 2nd half of split line", function() {
+      context('and user adds text to the end of 2nd half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on fist half of last split line
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").last().next();
-          $secondHalfOfSplitLine.sendkeys("{selectall}{rightarrow}");
-          $secondHalfOfSplitLine.sendkeys("something{enter}else");
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').last().next();
+          $secondHalfOfSplitLine.sendkeys('{selectall}{rightarrow}');
+          $secondHalfOfSplitLine.sendkeys('something{enter}else');
 
           // wait for changes to be processed and pagination to finish
           helper.waitFor(function() {
-            var $lineAfterPageBreak = inner$("div:has(splitPageBreak)").last().next().next();
-            return $lineAfterPageBreak.text() === "else";
+            var $lineAfterPageBreak = inner$('div:has(splitPageBreak)').last().next().next();
+            return $lineAfterPageBreak.text() === 'else';
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var lineAfterPageBreak = function() { return helper.padInner$("div:has(splitPageBreak)").last().next().next() };
+        it('keeps caret at the end of inserted text', function(done) {
+          var lineAfterPageBreak = function() { return helper.padInner$('div:has(splitPageBreak)').last().next().next() };
           var textAfterInsertedText = lineAfterPageBreak().text().length;
 
           splitElements.testCaretIsOn(lineAfterPageBreak, textAfterInsertedText, true, done);
         });
       });
 
-      context("and user adds text to the beginning of 2nd half of split line", function() {
+      context('and user adds text to the beginning of 2nd half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
 
           var inner$ = helper.padInner$;
 
           // write something on second half of last split line
-          // ("2." will be moved to 1st half; "AAAAAAAAA" to the 2nd)
-          var $secondHalfOfSplitLine = inner$("div:has(splitPageBreak)").last().next();
+          // ('2.' will be moved to 1st half; 'AAAAAAAAA' to the 2nd)
+          var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').last().next();
           // sendkeys fails if we apply it to <div>. Need to apply to the inner span
-          $secondHalfOfSplitLine = $secondHalfOfSplitLine.find("span");
-          $secondHalfOfSplitLine.sendkeys("{selectall}{leftarrow}");
-          $secondHalfOfSplitLine.sendkeys("2. AAAAAAAAA");
+          $secondHalfOfSplitLine = $secondHalfOfSplitLine.find('span');
+          $secondHalfOfSplitLine.sendkeys('{selectall}{leftarrow}');
+          $secondHalfOfSplitLine.sendkeys('2. AAAAAAAAA');
 
-          var textBeforePageBreak = sentences[0] + sentences[1] + "2. ";
+          var textBeforePageBreak = sentences[0] + sentences[1] + '2. ';
           // wait for pagination to finish
           helper.waitFor(function() {
-            var $firstHalfOfSplitLine = inner$("div:has(splitPageBreak)").last();
+            var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').last();
             return utils.cleanText($firstHalfOfSplitLine.text()) === textBeforePageBreak;
           }, 3000).done(done);
         });
 
-        it("keeps caret at the end of inserted text", function(done) {
-          var secondHalfOfSplitLine = function() { return helper.padInner$("div:has(splitPageBreak)").last().next() };
-          var textAfterInsertedText = "AAAAAAAAA".length;
+        it('keeps caret at the end of inserted text', function(done) {
+          var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
+          var textAfterInsertedText = 'AAAAAAAAA'.length;
 
           splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, true, done);
         });
@@ -1286,83 +1286,83 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
     });
   });
 
-  context("when first line of page is a very long transition", function() {
+  context('when first line of page is a very long transition', function() {
     before(function() {
       buildTargetElement = function() {
         return utils.transition(targetElementText);
       };
     });
 
-    context("and there is room on previous page for minimum number of lines (1)", function() {
+    context('and there is room on previous page for minimum number of lines (1)', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-        var line1 = utils.buildStringWithLength(14, "1") + ". ";
+        var line1 = utils.buildStringWithLength(14, '1') + '. ';
         // build sentence that is ~1.25 line long (when split it needs 2 lines)
-        var line2 = utils.buildStringWithLength(19, "2") + ". ";
+        var line2 = utils.buildStringWithLength(19, '2') + '. ';
         sentences = [line1, line2];
         targetElementText = line1 + line2;
       });
 
-      it("splits transition between the two pages, and first page has one line of the transition", function(done) {
+      it('splits transition between the two pages, and first page has one line of the transition', function(done) {
         // as line is split into two blocks, the page break will be placed on the
         // first 15 chars of original second sentence
         var newThirdLine = sentences[1];
         utils.testSplitPageBreakIsOn(newThirdLine, done);
       });
 
-      it("does not add the MORE/CONT'D tags", function(done) {
+      it('does not add the MORE/CONT\'D tags', function(done) {
         utils.testPageBreakDoNotHaveMoreNorContd(done);
       });
 
-      context("but next page will have less then the minimum lines (2) of an transition", function() {
+      context('but next page will have less then the minimum lines (2) of an transition', function() {
         before(function() {
-          var line1 = utils.buildStringWithLength(14, "1") + ". ";
-          var line2 = utils.buildStringWithLength(14, "2") + ". ";
+          var line1 = utils.buildStringWithLength(14, '1') + '. ';
+          var line2 = utils.buildStringWithLength(14, '2') + '. ';
           sentences = [line1, line2];
           targetElementText = line1 + line2;
         });
 
-        it("moves the entire transition for next page", function(done) {
+        it('moves the entire transition for next page', function(done) {
           var wholeElement = targetElementText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
         });
       });
     });
 
-    context("and there is room on previous page for more than the minimum line (more than 1)", function() {
+    context('and there is room on previous page for more than the minimum line (more than 1)', function() {
       before(function() {
         // give enough space for first 3 lines of transition to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
-        var line1 = utils.buildStringWithLength(14, "1") + ". ";
-        var line2 = utils.buildStringWithLength(14, "2") + ". ";
-        var line3 = utils.buildStringWithLength(14, "3") + ". ";
-        var line4 = utils.buildStringWithLength(14, "4") + ". ";
-        var line5 = utils.buildStringWithLength(14, "5") + ". ";
-        var line6 = utils.buildStringWithLength(14, "6") + ". ";
+        var line1 = utils.buildStringWithLength(14, '1') + '. ';
+        var line2 = utils.buildStringWithLength(14, '2') + '. ';
+        var line3 = utils.buildStringWithLength(14, '3') + '. ';
+        var line4 = utils.buildStringWithLength(14, '4') + '. ';
+        var line5 = utils.buildStringWithLength(14, '5') + '. ';
+        var line6 = utils.buildStringWithLength(14, '6') + '. ';
         sentences = [line1, line2, line3, line4, line5, line6];
         targetElementText = line1 + line2 + line3 + line4 + line5 + line6;
       });
 
-      it("splits transition between the two pages, and first page has as much lines as it can fit", function(done) {
+      it('splits transition between the two pages, and first page has as much lines as it can fit', function(done) {
         var targetLine = sentences[3];
         utils.testSplitPageBreakIsOn(targetLine, done);
       });
 
-      context("but next page will have less then the minimum lines (2) of an transition", function() {
+      context('but next page will have less then the minimum lines (2) of an transition', function() {
         before(function() {
           // give enough space for first 5 lines of transition to fit on first page (which would leave
           // only one line on next page)
           linesBeforeTargetElement = GENERALS_PER_PAGE - 6;
         });
 
-        it("splits transition between the two pages, and second page keep the minimum lines it needs", function(done) {
+        it('splits transition between the two pages, and second page keep the minimum lines it needs', function(done) {
           var targetLine = sentences[4];
           utils.testSplitPageBreakIsOn(targetLine, done);
         });
       });
     });
 
-    context("and transition is longer than a full page", function() {
+    context('and transition is longer than a full page', function() {
       var sentences, transitionText;
 
       before(function() {
@@ -1377,16 +1377,16 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         var numberOfInnerLines = GENERALS_PER_PAGE+2;
         var charsPerLine = 16;
         sentences = splitElements.buildLongLine(numberOfInnerLines, charsPerLine);
-        targetElementText = sentences.join("");
+        targetElementText = sentences.join('');
         transitionText = targetElementText;
       });
 
-      it("splits transition between the two pages, and second page has the last two lines of the transition", function(done) {
+      it('splits transition between the two pages, and second page has the last two lines of the transition', function(done) {
         var firstLineOnPage2 = sentences[GENERALS_PER_PAGE];
         utils.testSplitPageBreakIsOn(firstLineOnPage2, done);
       });
 
-      context("and transition has " + (GENERALS_PER_PAGE+1) + " inner lines", function() {
+      context('and transition has ' + (GENERALS_PER_PAGE+1) + ' inner lines', function() {
         before(function() {
           // build a string GENERALS_PER_PAGE+1 lines long, so page split will be:
           // page 1: GENERALS_PER_PAGE-1 lines;
@@ -1394,11 +1394,11 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           var numberOfInnerLines = GENERALS_PER_PAGE+1;
           var charsPerLine = 16;
           sentences = splitElements.buildLongLine(numberOfInnerLines, charsPerLine);
-          targetElementText = sentences.join("");
+          targetElementText = sentences.join('');
           transitionText = targetElementText;
         });
 
-        it("splits transition between the two pages, and second page has the last two lines of the transition", function(done) {
+        it('splits transition between the two pages, and second page has the last two lines of the transition', function(done) {
           this.timeout(4000);
 
           var firstLineOnPage2 = sentences[GENERALS_PER_PAGE-1];
@@ -1406,16 +1406,16 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         });
       });
 
-      context("and there is a general before the transition", function() {
+      context('and there is a general before the transition', function() {
         before(function() {
           linesBeforeTargetElement = 1;
 
           // pagination will split last line, so we need to get only the part that will be on 2nd half
           var sentencesOnLastPage = sentences.slice(GENERALS_PER_PAGE-3);
-          targetElementText = sentencesOnLastPage.join("");
+          targetElementText = sentencesOnLastPage.join('');
         });
 
-        it("splits transition between the two pages, and second page has the last three lines of the transition", function(done) {
+        it('splits transition between the two pages, and second page has the last three lines of the transition', function(done) {
           this.timeout(4000);
 
           var firstLineOnPage2 = sentences[GENERALS_PER_PAGE-2];
@@ -1423,7 +1423,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         });
       });
 
-      context("and there are generals after the transition", function() {
+      context('and there are generals after the transition', function() {
         before(function() {
           linesBeforeTargetElement = 0;
 
@@ -1431,8 +1431,8 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           // page 1: 1st half of transition, with GENERALS_PER_PAGE-1 lines;
           // page 2: 2nd half of transition, with 2 lines + GENERALS_PER_PAGE-2 generals
           // page 3: 1 general
-          var pageFilledWithGenerals = utils.general("general on 2nd page").repeat(GENERALS_PER_PAGE-2);
-          targetElementText = "general on 3rd page";
+          var pageFilledWithGenerals = utils.general('general on 2nd page').repeat(GENERALS_PER_PAGE-2);
+          targetElementText = 'general on 3rd page';
 
           buildTargetElement = function() {
             return utils.transition(transitionText) + pageFilledWithGenerals + utils.general(targetElementText);
@@ -1446,7 +1446,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           };
         });
 
-        it("considers the height of the resulting second half of the transition split", function(done) {
+        it('considers the height of the resulting second half of the transition split', function(done) {
           var firstLineOnPage3 = targetElementText;
           var pageNumber = 3;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(firstLineOnPage3, done, 3);
@@ -1454,7 +1454,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
       });
 
       // FIXME this is an extreme corner case, so we won't work on it for now
-      context("and inner lines do not have full length", function() {
+      context('and inner lines do not have full length', function() {
         before(function() {
           linesBeforeTargetElement = 0;
 
@@ -1462,78 +1462,78 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           // fill 9 out of 16 columns of each inner line
           var charsPerLine = 9;
           sentences = splitElements.buildLongLine(numberOfInnerLines, charsPerLine);
-          targetElementText = sentences.join("");
+          targetElementText = sentences.join('');
         });
 
-        xit("splits transition between the two pages, and second page has the last two lines of the transition", function(done) {
+        xit('splits transition between the two pages, and second page has the last two lines of the transition', function(done) {
           var firstLineOnPage2 = sentences[GENERALS_PER_PAGE-1];
           utils.testSplitPageBreakIsOn(firstLineOnPage2, done);
         });
       });
     });
 
-    context("and there are whitespaces but no punctuation mark on line that fits on previous page", function() {
+    context('and there are whitespaces but no punctuation mark on line that fits on previous page', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-        var line1 = utils.buildStringWithLength(10, "1") + " 1 ";
-        var line2 = utils.buildStringWithLength(16, "2");
-        var line3 = utils.buildStringWithLength(16, "3");
+        var line1 = utils.buildStringWithLength(10, '1') + ' 1 ';
+        var line2 = utils.buildStringWithLength(16, '2');
+        var line3 = utils.buildStringWithLength(16, '3');
         sentences = [line1, line2, line3];
-        targetElementText = sentences.join("");
+        targetElementText = sentences.join('');
         buildTargetElement = function() {
           return utils.transition(targetElementText);
         };
       });
 
-      it("splits line by whitespace", function(done) {
+      it('splits line by whitespace', function(done) {
         var secondAndThirdLines = sentences[1] + sentences[2];
         utils.testSplitPageBreakIsOn(secondAndThirdLines, done);
       });
     });
 
-    context("and there are no whitespaces nor punctuation marks on line that fits on previous page", function() {
+    context('and there are no whitespaces nor punctuation marks on line that fits on previous page', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-        var line1 = utils.buildStringWithLength(16, "1");
-        var line2 = utils.buildStringWithLength(16, "2");
-        var line3 = "3";
+        var line1 = utils.buildStringWithLength(16, '1');
+        var line2 = utils.buildStringWithLength(16, '2');
+        var line3 = '3';
         sentences = [line1, line2, line3];
-        targetElementText = sentences.join("");
+        targetElementText = sentences.join('');
       });
 
-      it("forces transition to be split at the end of first line", function(done) {
+      it('forces transition to be split at the end of first line', function(done) {
         var secondAndThirdLines = sentences[1] + sentences[2];
         utils.testSplitPageBreakIsOn(secondAndThirdLines, done);
       });
     });
   });
 
-  context("when first line of page is a very long dialogue", function() {
+  context('when first line of page is a very long dialogue', function() {
     before(function() {
       buildTargetElement = function() {
         return utils.dialogue(targetElementText);
       };
     });
 
-    context("and there is room on previous page for minimum number of lines (1)", function() {
+    context('and there is room on previous page for minimum number of lines (1)', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var line1 = utils.buildStringWithLength(33, "1") + ". ";
+        var line1 = utils.buildStringWithLength(33, '1') + '. ';
         // build sentence that is ~1.25 line long (when split it needs 2 lines)
-        var line2 = utils.buildStringWithLength(44, "2") + ". ";
+        var line2 = utils.buildStringWithLength(44, '2') + '. ';
         sentences = [line1, line2];
         targetElementText = line1 + line2;
       });
 
-      it("splits dialogue between the two pages, and first page has one line of the dialogue", function(done) {
+      it('splits dialogue between the two pages, and first page has one line of the dialogue', function(done) {
         // as line is split into two blocks, the page break will be placed on the
         // first 35 chars of original second sentence
         var newThirdLine = sentences[1];
         utils.testSplitPageBreakIsOn(newThirdLine, done);
       });
 
-      context("but there is a character before dialogue", function() {
-        var characterName = "joe's (V.O.)";
+      context('but there is a character before dialogue', function() {
+        var characterName = 'joe\'s (V.O.)';
 
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
@@ -1550,98 +1550,98 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           };
         });
 
-        it("moves the entire dialogue and character for next page", function(done) {
+        it('moves the entire dialogue and character for next page', function(done) {
           utils.testNonSplitPageBreakIsOnScriptElementWithText(characterName, done);
         });
       });
 
-      context("but next page will have less then the minimum lines (2) of an dialogue", function() {
+      context('but next page will have less then the minimum lines (2) of an dialogue', function() {
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-          var line1 = utils.buildStringWithLength(33, "1") + ". ";
-          var line2 = utils.buildStringWithLength(33, "2") + ". ";
+          var line1 = utils.buildStringWithLength(33, '1') + '. ';
+          var line2 = utils.buildStringWithLength(33, '2') + '. ';
           sentences = [line1, line2];
           targetElementText = line1 + line2;
         });
 
-        it("moves the entire dialogue for next page", function(done) {
+        it('moves the entire dialogue for next page', function(done) {
           var wholeElement = targetElementText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
         });
       });
     });
 
-    context("and there is room on previous page for more than the minimum line (more than 1)", function() {
+    context('and there is room on previous page for more than the minimum line (more than 1)', function() {
       before(function() {
         // give enough space for first 3 lines of dialogue to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
-        var line1 = utils.buildStringWithLength(33, "1") + ". ";
-        var line2 = utils.buildStringWithLength(33, "2") + ". ";
-        var line3 = utils.buildStringWithLength(33, "3") + ". ";
-        var line4 = utils.buildStringWithLength(33, "4") + ". ";
-        var line5 = utils.buildStringWithLength(33, "5") + ". ";
-        var line6 = utils.buildStringWithLength(33, "6") + ". ";
+        var line1 = utils.buildStringWithLength(33, '1') + '. ';
+        var line2 = utils.buildStringWithLength(33, '2') + '. ';
+        var line3 = utils.buildStringWithLength(33, '3') + '. ';
+        var line4 = utils.buildStringWithLength(33, '4') + '. ';
+        var line5 = utils.buildStringWithLength(33, '5') + '. ';
+        var line6 = utils.buildStringWithLength(33, '6') + '. ';
         sentences = [line1, line2, line3, line4, line5, line6];
         targetElementText = line1 + line2 + line3 + line4 + line5 + line6;
       });
 
-      it("splits dialogue between the two pages, and first page has as much lines as it can fit", function(done) {
+      it('splits dialogue between the two pages, and first page has as much lines as it can fit', function(done) {
         var targetLine = sentences[3];
         utils.testSplitPageBreakIsOn(targetLine, done);
       });
 
-      context("but next page will have less then the minimum lines (2) of a dialogue", function() {
+      context('but next page will have less then the minimum lines (2) of a dialogue', function() {
         before(function() {
           // give enough space for first 5 lines of dialogue to fit on first page (which would leave
           // only one line on next page)
           linesBeforeTargetElement = GENERALS_PER_PAGE - 5;
         });
 
-        it("splits dialogue between the two pages, and second page keep the minimum lines it needs", function(done) {
+        it('splits dialogue between the two pages, and second page keep the minimum lines it needs', function(done) {
           var targetLine = sentences[4];
           utils.testSplitPageBreakIsOn(targetLine, done);
         });
       });
 
-      context("and there is no character before dialogue", function() {
+      context('and there is no character before dialogue', function() {
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-          var line1 = utils.buildStringWithLength(45, "1") + ". ";
-          var line2 = utils.buildStringWithLength(45, "2") + ". ";
+          var line1 = utils.buildStringWithLength(45, '1') + '. ';
+          var line2 = utils.buildStringWithLength(45, '2') + '. ';
           sentences = [line1, line2];
           targetElementText = line1 + line2;
         });
 
-        it("adds the MORE/CONT'D tags with an empty character name", function(done) {
+        it('adds the MORE/CONT\'D tags with an empty character name', function(done) {
           this.timeout(4000);
 
-          var characterName = "";
+          var characterName = '';
           utils.testPageBreakHasMoreAndContd(characterName, done);
         });
 
-        context("and 2nd split starts with a short sentence", function() {
+        context('and 2nd split starts with a short sentence', function() {
           before(function() {
-            var line1 = utils.buildStringWithLength(33, "1") + ". ";
-            var line2 = utils.buildStringWithLength(33, "2") + ". ";
-            var line3 = "3 " + utils.buildStringWithLength(30, "3") + ". "; // "3 " is the short sentence
-            var line4 = utils.buildStringWithLength(32, "4") + ". ";
+            var line1 = utils.buildStringWithLength(33, '1') + '. ';
+            var line2 = utils.buildStringWithLength(33, '2') + '. ';
+            var line3 = '3 ' + utils.buildStringWithLength(30, '3') + '. '; // '3 ' is the short sentence
+            var line4 = utils.buildStringWithLength(32, '4') + '. ';
             sentences = [line1, line2, line3, line4];
             targetElementText = line1 + line2 + line3 + line4;
           });
 
-          // this test is for the CSS of page break and MORE/CONT'D
-          it("still places the 2nd half of split on the line below CONT'D", function(done) {
+          // this test is for the CSS of page break and MORE/CONT\'D
+          it('still places the 2nd half of split on the line below CONT\'D', function(done) {
             this.timeout(4000);
 
             var inner$ = helper.padInner$;
 
             // wait for pagination to be finished
             helper.waitFor(function() {
-              var $splitPageBreaks = inner$("div splitPageBreak");
+              var $splitPageBreaks = inner$('div splitPageBreak');
               return $splitPageBreaks.length > 0;
             }, 2000).done(function() {
               // verify 2nd half is two-lines high
-              var secondHalfHeight = inner$("div").last().prev().outerHeight();
+              var secondHalfHeight = inner$('div').last().prev().outerHeight();
               var twoLinesHigh = 2 * utils.regularLineHeight();
 
               expect(secondHalfHeight).to.be(twoLinesHigh);
@@ -1654,10 +1654,10 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
       // FIXME Line numbers are not aligned to correspondent text line
       // https://trello.com/c/hdZGr9EA/684
-      context.skip("and there is a very long character before dialogue", function() {
+      context.skip('and there is a very long character before dialogue', function() {
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
-          var character = utils.character("VERY LOOOOOOOOOOOOOONG CHARACTER NAME");
+          var character = utils.character('VERY LOOOOOOOOOOOOOONG CHARACTER NAME');
           var dialogue = utils.dialogue(targetElementText);
           buildTargetElement = function() {
             return character + dialogue;
@@ -1670,17 +1670,17 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           };
         });
 
-        // this test is for the CSS of CONT'D (see comments about ellipsis on CSS file and fixSmallZoom.js)
-        it("only uses one line to display character name and CONT'D", function(done) {
+        // this test is for the CSS of CONT\'D (see comments about ellipsis on CSS file and fixSmallZoom.js)
+        it('only uses one line to display character name and CONT\'D', function(done) {
           var theTest = this;
           var inner$ = helper.padInner$;
 
           // wait for pagination to be finished
           helper.waitFor(function() {
-            var $splitPageBreaks = inner$("div splitPageBreak");
+            var $splitPageBreaks = inner$('div splitPageBreak');
             return $splitPageBreaks.length > 0;
           }).done(function() {
-            // verify CONT'D is one line high
+            // verify CONT\'D is one line high
             // (if it is not, line number and line position on editor will be different)
             var firstLineOfSecondPage = GENERALS_PER_PAGE-1;
             utils.testLineNumberIsOnTheSamePositionOfItsLineText(firstLineOfSecondPage, theTest, done);
@@ -1688,8 +1688,8 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
         });
       });
 
-      context("and there is a character before dialogue", function() {
-        var characterName = "joe's (V.O.)";
+      context('and there is a character before dialogue', function() {
+        var characterName = 'joe\'s (V.O.)';
 
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
@@ -1706,22 +1706,22 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           };
         });
 
-        it("splits dialogue between the two pages", function(done) {
+        it('splits dialogue between the two pages', function(done) {
           var thirdLine = sentences[2];
           utils.testSplitPageBreakIsOn(thirdLine, done);
         });
 
-        it("adds the MORE/CONT'D tags with character name upper cased", function(done) {
+        it('adds the MORE/CONT\'D tags with character name upper cased', function(done) {
           utils.testPageBreakHasMoreAndContd(characterName.toUpperCase(), done);
         });
 
-        context("but previous page will have less then the minimum lines (2) of an dialogue preceded by a character", function() {
+        context('but previous page will have less then the minimum lines (2) of an dialogue preceded by a character', function() {
           before(function() {
             // give enough space for character + two lines of dialogue to fit on first page
             linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
-            var line1 = utils.buildStringWithLength(33, "1") + ". ";
-            var line2 = utils.buildStringWithLength(33, "2") + ". ";
-            var line3 = utils.buildStringWithLength(33, "3") + ". ";
+            var line1 = utils.buildStringWithLength(33, '1') + '. ';
+            var line2 = utils.buildStringWithLength(33, '2') + '. ';
+            var line3 = utils.buildStringWithLength(33, '3') + '. ';
             sentences = [line1, line2, line3];
             targetElementText = line1 + line2 + line3;
             var character = utils.character(characterName);
@@ -1731,7 +1731,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
             };
           });
 
-          it("moves the entire dialogue and character for next page", function(done) {
+          it('moves the entire dialogue and character for next page', function(done) {
             utils.testNonSplitPageBreakIsOnScriptElementWithText(characterName, done);
           });
         });
@@ -1739,32 +1739,32 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
     });
   });
 
-  context("when first line of page is a very long parenthetical", function() {
+  context('when first line of page is a very long parenthetical', function() {
     before(function() {
       buildTargetElement = function() {
         return utils.parenthetical(targetElementText);
       };
     });
 
-    context("and there is room on previous page for minimum number of lines (1)", function() {
+    context('and there is room on previous page for minimum number of lines (1)', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-        var line1 = utils.buildStringWithLength(23, "1") + ". ";
+        var line1 = utils.buildStringWithLength(23, '1') + '. ';
         // build sentence that is ~1.25 line long (when split it needs 2 lines)
-        var line2 = utils.buildStringWithLength(30, "2") + ". ";
+        var line2 = utils.buildStringWithLength(30, '2') + '. ';
         sentences = [line1, line2];
         targetElementText = line1 + line2;
       });
 
-      it("splits parenthetical between the two pages, and first page has one line of the parenthetical", function(done) {
+      it('splits parenthetical between the two pages, and first page has one line of the parenthetical', function(done) {
         // as line is split into two blocks, the page break will be placed on the
         // first 25 chars of original second sentence
         var newThirdLine = sentences[1];
         utils.testSplitPageBreakIsOn(newThirdLine, done);
       });
 
-      context("but there is a character before parenthetical", function() {
-        var characterName = "joe's (V.O.)";
+      context('but there is a character before parenthetical', function() {
+        var characterName = 'joe\'s (V.O.)';
 
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
@@ -1781,87 +1781,87 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           };
         });
 
-        it("moves the entire parenthetical and character for next page", function(done) {
+        it('moves the entire parenthetical and character for next page', function(done) {
           utils.testNonSplitPageBreakIsOnScriptElementWithText(characterName, done);
         });
       });
 
       // FIXME flaky tests on this context. They only fail on Semaphore, apparently
-      context.skip("but next page will have less then the minimum lines (2) of a parenthetical", function() {
+      context.skip('but next page will have less then the minimum lines (2) of a parenthetical', function() {
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
-          var line1 = utils.buildStringWithLength(23, "1") + ". ";
-          var line2 = utils.buildStringWithLength(23, "2") + ". ";
+          var line1 = utils.buildStringWithLength(23, '1') + '. ';
+          var line2 = utils.buildStringWithLength(23, '2') + '. ';
           sentences = [line1, line2];
           targetElementText = line1 + line2;
         });
 
-        it("moves the entire parenthetical for next page", function(done) {
+        it('moves the entire parenthetical for next page', function(done) {
           var wholeElement = targetElementText;
           utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
         });
       });
     });
 
-    context("and there is room on previous page for more than the minimum line (more than 1)", function() {
+    context('and there is room on previous page for more than the minimum line (more than 1)', function() {
       before(function() {
         // give enough space for first 3 lines of parenthetical to fit on first page
         linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
-        var line1 = utils.buildStringWithLength(23, "1") + ". ";
-        var line2 = utils.buildStringWithLength(23, "2") + ". ";
-        var line3 = utils.buildStringWithLength(23, "3") + ". ";
-        var line4 = utils.buildStringWithLength(23, "4") + ". ";
-        var line5 = utils.buildStringWithLength(23, "5") + ". ";
-        var line6 = utils.buildStringWithLength(23, "6") + ". ";
+        var line1 = utils.buildStringWithLength(23, '1') + '. ';
+        var line2 = utils.buildStringWithLength(23, '2') + '. ';
+        var line3 = utils.buildStringWithLength(23, '3') + '. ';
+        var line4 = utils.buildStringWithLength(23, '4') + '. ';
+        var line5 = utils.buildStringWithLength(23, '5') + '. ';
+        var line6 = utils.buildStringWithLength(23, '6') + '. ';
         sentences = [line1, line2, line3, line4, line5, line6];
         targetElementText = line1 + line2 + line3 + line4 + line5 + line6;
       });
 
-      it("splits parenthetical between the two pages, and first page has as much lines as it can fit", function(done) {
+      it('splits parenthetical between the two pages, and first page has as much lines as it can fit', function(done) {
         var targetLine = sentences[3];
         utils.testSplitPageBreakIsOn(targetLine, done);
       });
 
       // FIXME flaky tests on this context. They only fail on Semaphore, apparently
-      context.skip("but next page will have less then the minimum lines (2) of a parenthetical", function() {
+      context.skip('but next page will have less then the minimum lines (2) of a parenthetical', function() {
         before(function() {
           // give enough space for first 5 lines of parenthetical to fit on first page (which would leave
           // only one line on next page)
           linesBeforeTargetElement = GENERALS_PER_PAGE - 5;
         });
 
-        it("splits parenthetical between the two pages, and second page keep the minimum lines it needs", function(done) {
+        it('splits parenthetical between the two pages, and second page keep the minimum lines it needs', function(done) {
           var targetLine = sentences[4];
           utils.testSplitPageBreakIsOn(targetLine, done);
         });
       });
 
-      context("and there is no character before parenthetical", function() {
+      context('and there is no character before parenthetical', function() {
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
-          var line1 = utils.buildStringWithLength(30, "1") + ". ";
-          var line2 = utils.buildStringWithLength(30, "2") + ". ";
+          var line1 = utils.buildStringWithLength(30, '1') + '. ';
+          var line2 = utils.buildStringWithLength(30, '2') + '. ';
           sentences = [line1, line2];
           targetElementText = line1 + line2;
         });
 
-        it("adds the MORE/CONT'D tags with an empty character name", function(done) {
-          var characterName = "";
+        it('adds the MORE/CONT\'D tags with an empty character name', function(done) {
+          var characterName = '';
           utils.testPageBreakHasMoreAndContd(characterName, done);
         });
       });
 
-      context("and there is a character before parenthetical", function() {
-        var characterName = "joe's (V.O.)";
+      context('and there is a character before parenthetical', function() {
+        var characterName = 'joe\'s (V.O.)';
 
         before(function() {
           linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
-          var line1 = utils.buildStringWithLength(23, "1") + ". ";
-          var line2 = utils.buildStringWithLength(23, "2") + ". ";
-          var line3 = utils.buildStringWithLength(23, "3") + ". ";
-          var line4 = utils.buildStringWithLength(23, "4") + ". ";
-          var line5 = utils.buildStringWithLength(23, "5") + ". ";
-          var line6 = utils.buildStringWithLength(23, "6") + ". ";
+          var line1 = utils.buildStringWithLength(23, '1') + '. ';
+          var line2 = utils.buildStringWithLength(23, '2') + '. ';
+          var line3 = utils.buildStringWithLength(23, '3') + '. ';
+          var line4 = utils.buildStringWithLength(23, '4') + '. ';
+          var line5 = utils.buildStringWithLength(23, '5') + '. ';
+          var line6 = utils.buildStringWithLength(23, '6') + '. ';
           sentences = [line1, line2, line3, line4, line5, line6];
           targetElementText = line1 + line2 + line3 + line4 + line5 + line6;
           var character = utils.character(characterName);
@@ -1878,23 +1878,23 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
           };
         });
 
-        it("splits parenthetical between the two pages", function(done) {
+        it('splits parenthetical between the two pages', function(done) {
           var thirdLine = sentences[2];
           utils.testSplitPageBreakIsOn(thirdLine, done);
         });
 
-        it("adds the MORE/CONT'D tags with character name upper cased", function(done) {
+        it('adds the MORE/CONT\'D tags with character name upper cased', function(done) {
           utils.testPageBreakHasMoreAndContd(characterName.toUpperCase(), done);
         });
 
         // FIXME flaky tests on this context. They only fail on Semaphore, apparently
-        context.skip("but previous page will have less then the minimum lines (2) of a parenthetical preceded by a character", function() {
+        context.skip('but previous page will have less then the minimum lines (2) of a parenthetical preceded by a character', function() {
           before(function() {
             // give enough space for character + two lines of parenthetical to fit on first page
             linesBeforeTargetElement = GENERALS_PER_PAGE - 4;
-            var line1 = utils.buildStringWithLength(23, "1") + ". ";
-            var line2 = utils.buildStringWithLength(23, "2") + ". ";
-            var line3 = utils.buildStringWithLength(23, "3") + ". ";
+            var line1 = utils.buildStringWithLength(23, '1') + '. ';
+            var line2 = utils.buildStringWithLength(23, '2') + '. ';
+            var line3 = utils.buildStringWithLength(23, '3') + '. ';
             sentences = [line1, line2, line3];
             targetElementText = line1 + line2 + line3;
             var character = utils.character(characterName);
@@ -1904,7 +1904,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
             };
           });
 
-          it("moves the entire parenthetical and character for next page", function(done) {
+          it('moves the entire parenthetical and character for next page', function(done) {
             utils.testNonSplitPageBreakIsOnScriptElementWithText(characterName, done);
           });
         });
@@ -1912,55 +1912,55 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
     });
   });
 
-  context("when first line of page is a very long heading", function() {
+  context('when first line of page is a very long heading', function() {
     before(function() {
       linesBeforeTargetElement = GENERALS_PER_PAGE - 7;
-      var line1 = utils.buildStringWithLength(59, "1") + ". ";
-      var line2 = utils.buildStringWithLength(59, "2") + ". ";
+      var line1 = utils.buildStringWithLength(59, '1') + '. ';
+      var line2 = utils.buildStringWithLength(59, '2') + '. ';
       targetElementText = line1 + line2;
       buildTargetElement = function() {
         var firstHeadingWithActAndSeq = utils.heading('First Heading');
-        var generalInTheMiddle = utils.general("general between headings");
+        var generalInTheMiddle = utils.general('general between headings');
         var targetHeading = utils.heading(targetElementText);
         return firstHeadingWithActAndSeq + generalInTheMiddle + targetHeading;
       };
     });
 
-    it("does not split heading into two parts, one on each page", function(done) {
+    it('does not split heading into two parts, one on each page', function(done) {
       var fullElementText = targetElementText;
       utils.testNonSplitPageBreakIsOnScriptElementWithText(fullElementText, done);
     });
   });
 
-  context("when first line of page is a very long shot", function() {
+  context('when first line of page is a very long shot', function() {
     before(function() {
       linesBeforeTargetElement = GENERALS_PER_PAGE - 3;
-      var line1 = utils.buildStringWithLength(59, "1") + ". ";
-      var line2 = utils.buildStringWithLength(59, "2") + ". ";
+      var line1 = utils.buildStringWithLength(59, '1') + '. ';
+      var line2 = utils.buildStringWithLength(59, '2') + '. ';
       targetElementText = line1 + line2;
       buildTargetElement = function() {
         return utils.shot(targetElementText);
       };
     });
 
-    it("does not split shot into two parts, one on each page", function(done) {
+    it('does not split shot into two parts, one on each page', function(done) {
       var fullElementText = targetElementText;
       utils.testNonSplitPageBreakIsOnScriptElementWithText(fullElementText, done);
     });
   });
 
-  context("when first line of page is a very long character", function() {
+  context('when first line of page is a very long character', function() {
     before(function() {
       linesBeforeTargetElement = GENERALS_PER_PAGE - 2;
-      var line1 = utils.buildStringWithLength(36, "1") + ". ";
-      var line2 = utils.buildStringWithLength(36, "2") + ". ";
+      var line1 = utils.buildStringWithLength(36, '1') + '. ';
+      var line2 = utils.buildStringWithLength(36, '2') + '. ';
       targetElementText = line1 + line2;
       buildTargetElement = function() {
         return utils.character(targetElementText);
       };
     });
 
-    it("does not split character into two parts, one on each page", function(done) {
+    it('does not split character into two parts, one on each page', function(done) {
       var fullElementText = targetElementText;
       utils.testNonSplitPageBreakIsOnScriptElementWithText(fullElementText, done);
     });
@@ -1974,13 +1974,13 @@ ep_script_page_view_test_helper.splitElements = {
     var utils = ep_script_page_view_test_helper.utils;
 
     // remove one line to force pagination again
-    var $firstLine = inner$("div").first();
+    var $firstLine = inner$('div').first();
     $firstLine.remove();
 
     // wait for pagination to finish
     helper.waitFor(function() {
-      var $splitElementsWithPageBreaks = inner$("div splitPageBreak");
-      var textBeforePageBreak = utils.cleanText($splitElementsWithPageBreaks.first().closest("div").text());
+      var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
+      var textBeforePageBreak = utils.cleanText($splitElementsWithPageBreaks.first().closest('div').text());
       return textBeforePageBreak === expectedTextBeforePageBreak;
     }, 3000).done(done);
   },
@@ -2013,8 +2013,8 @@ ep_script_page_view_test_helper.splitElements = {
     for (var i = 0; i < numberOfInnerLines; i++) {
       // formatted number is 4 chars long, and there is a whitespace at the end of line
       var extraChars = charsPerLine - 5;
-      // inner line is "0001XX(...)XX "
-      innerLines[i] = utils.formatNumber(i+1) + utils.buildStringWithLength(extraChars, "X") + " ";
+      // inner line is '0001XX(...)XX '
+      innerLines[i] = utils.formatNumber(i+1) + utils.buildStringWithLength(extraChars, 'X') + ' ';
     };
     return innerLines;
   },

--- a/static/tests/frontend/specs/utils.js
+++ b/static/tests/frontend/specs/utils.js
@@ -1,52 +1,52 @@
 var ep_script_page_view_test_helper = ep_script_page_view_test_helper || {};
 ep_script_page_view_test_helper.utils = {
   act: function(name, summary) {
-    return "<act_name>" + name + "</act_name><br/>" +
-           "<act_summary>" + summary + "</act_summary><br/>";
+    return '<act_name>' + name + '</act_name><br/>' +
+           '<act_summary>' + summary + '</act_summary><br/>';
   },
   sequence: function(name, summary) {
-    return "<sequence_name>" + name + "</sequence_name><br/>" +
-           "<sequence_summary>" + summary + "</sequence_summary><br/>";
+    return '<sequence_name>' + name + '</sequence_name><br/>' +
+           '<sequence_summary>' + summary + '</sequence_summary><br/>';
   },
   synopsis: function(name, summary) {
-    return "<scene_name>" + name + "</scene_name><br/>" +
-           "<scene_summary>" + summary + "</scene_summary><br/>";
+    return '<scene_name>' + name + '</scene_name><br/>' +
+           '<scene_summary>' + summary + '</scene_summary><br/>';
   },
   heading: function(text) {
-    return "<heading>" + text + "</heading><br/>";
+    return '<heading>' + text + '</heading><br/>';
   },
   action: function(text) {
-    return "<action>" + text + "</action><br/>";
+    return '<action>' + text + '</action><br/>';
   },
   parenthetical: function(text) {
-    return "<parenthetical>" + text + "</parenthetical><br/>";
+    return '<parenthetical>' + text + '</parenthetical><br/>';
   },
   character: function(text) {
-    return "<character>" + text + "</character><br/>";
+    return '<character>' + text + '</character><br/>';
   },
   dialogue: function(text) {
-    return "<dialogue>" + text + "</dialogue><br/>";
+    return '<dialogue>' + text + '</dialogue><br/>';
   },
   shot: function(text) {
-    return "<shot>" + text + "</shot><br/>";
+    return '<shot>' + text + '</shot><br/>';
   },
   transition: function(text) {
-    return "<transition>" + text + "</transition><br/>";
+    return '<transition>' + text + '</transition><br/>';
   },
   general: function(text) {
-    return text + "<br/>";
+    return text + '<br/>';
   },
   createScriptWith: function(scriptContent, lastLineText, cb) {
     var inner$ = helper.padInner$;
     var utils = ep_script_page_view_test_helper.utils;
 
     // set script content
-    var $firstLine = inner$("div").first();
+    var $firstLine = inner$('div').first();
     $firstLine.html(scriptContent);
 
     // wait for Etherpad to finish processing the lines
     helper.waitFor(function(){
-      var $lastLine = inner$("div").last();
+      var $lastLine = inner$('div').last();
       return utils.cleanText($lastLine.text()) === lastLineText;
     }, 3000).done(cb);
   },
@@ -62,10 +62,10 @@ ep_script_page_view_test_helper.utils = {
   clickOnAddAct: function(done) {
     var outer$ = helper.padOuter$;
     helper.waitFor(function() {
-      var mouseWindowIsVisible = outer$(".mouseWindow").length != 0;
+      var mouseWindowIsVisible = outer$('.mouseWindow').length != 0;
       return mouseWindowIsVisible;
     }, 2000).done(function() {
-      var $addActMenuOption = outer$("#addAct");
+      var $addActMenuOption = outer$('#addAct');
       $addActMenuOption.click();
       done();
     });
@@ -93,10 +93,10 @@ ep_script_page_view_test_helper.utils = {
     var chrome$ = helper.padChrome$;
 
     // click on the settings button to make settings visible
-    var $settingsButton = chrome$(".buttonicon-settings");
+    var $settingsButton = chrome$('.buttonicon-settings');
     $settingsButton.click();
 
-    // check "Line Numbers"
+    // check 'Line Numbers'
     var $showLineNumbers = chrome$('#options-linenoscheck');
     if ($showLineNumbers.is(':checked') !== shouldShowLineNumbers) $showLineNumbers.click();
 
@@ -112,12 +112,12 @@ ep_script_page_view_test_helper.utils = {
     helper.padChrome$.window.clientVars.plugins.plugins.ep_script_page_view.paginationDelay = 100;
 
     var inner$ = helper.padInner$;
-    var $padContent = inner$("#innerdocbody");
-    $padContent.html("");
+    var $padContent = inner$('#innerdocbody');
+    $padContent.html('');
 
     // wait for Etherpad to re-create first line
     helper.waitFor(function(){
-      var lineNumber = inner$("div").length;
+      var lineNumber = inner$('div').length;
       return lineNumber === 1;
     }, 2000).done(callback);
   },
@@ -127,7 +127,7 @@ ep_script_page_view_test_helper.utils = {
   // ...
   getLine: function(lineNum) {
     var inner$ = helper.padInner$;
-    var $line = inner$("div").first();
+    var $line = inner$('div').first();
     for (var i = lineNum - 1; i >= 0; i--) {
       $line = $line.next();
     }
@@ -135,8 +135,8 @@ ep_script_page_view_test_helper.utils = {
   },
   getLineNumber: function(lineNum) {
     var outer$ = helper.padOuter$;
-    var $lineNumbersContainer = outer$("#sidedivinner");
-    var $line = $lineNumbersContainer.find("div").first();
+    var $lineNumbersContainer = outer$('#sidedivinner');
+    var $line = $lineNumbersContainer.find('div').first();
     for (var i = lineNum - 1; i >= 0; i--) {
       $line = $line.next();
     }
@@ -146,7 +146,7 @@ ep_script_page_view_test_helper.utils = {
   getLineWhereCaretIs: function() {
     var inner$ = helper.padInner$;
     var nodeWhereCaretIs = inner$.document.getSelection().anchorNode;
-    var $lineWhereCaretIs = $(nodeWhereCaretIs).closest("div");
+    var $lineWhereCaretIs = $(nodeWhereCaretIs).closest('div');
 
     return $lineWhereCaretIs;
   },
@@ -158,7 +158,7 @@ ep_script_page_view_test_helper.utils = {
   },
 
   cleanText: function(text) {
-    return text.replace(/\s/gi, " ");
+    return text.replace(/\s/gi, ' ');
   },
 
   buildStringWithLength: function(length, text) {
@@ -168,7 +168,7 @@ ep_script_page_view_test_helper.utils = {
   buildScriptWithGenerals: function(text, howMany) {
     var utils = ep_script_page_view_test_helper.utils;
 
-    var script = "";
+    var script = '';
     for (var i = 0; i < howMany; i++) {
       script += utils.general(text);
     }
@@ -178,17 +178,17 @@ ep_script_page_view_test_helper.utils = {
 
   undo: function() {
     var chrome$ = helper.padChrome$;
-    var $undoButton = chrome$(".buttonicon-undo");
+    var $undoButton = chrome$('.buttonicon-undo');
     $undoButton.click();
   },
 
   regularLineHeight: function() {
-    var $editor = helper.padInner$("#innerdocbody");
-    return parseFloat($editor.css("line-height"));
+    var $editor = helper.padInner$('#innerdocbody');
+    return parseFloat($editor.css('line-height'));
   },
   heightOf: function($element, pseudoElementName) {
     var pageBreak      = $element.get(0);
-    var pageBreakStyle = helper.padInner$.window.getComputedStyle(pageBreak, ":before");
+    var pageBreakStyle = helper.padInner$.window.getComputedStyle(pageBreak, ':before');
 
     var marginTop      = parseFloat(pageBreakStyle.marginTop);
     var paddingBottom  = parseFloat(pageBreakStyle.paddingBottom);
@@ -202,13 +202,13 @@ ep_script_page_view_test_helper.utils = {
   },
   heightOfSplitPageBreak: function() {
     var inner$ = helper.padInner$;
-    var $splitPageBreak = inner$("div splitPageBreak").first();
-    return ep_script_page_view_test_helper.utils.heightOf($splitPageBreak, ":before");
+    var $splitPageBreak = inner$('div splitPageBreak').first();
+    return ep_script_page_view_test_helper.utils.heightOf($splitPageBreak, ':before');
   },
   heightOfMore: function() {
     var inner$ = helper.padInner$;
-    var $more = inner$("div more").first();
-    return ep_script_page_view_test_helper.utils.heightOf($more, ":before");
+    var $more = inner$('div more').first();
+    return ep_script_page_view_test_helper.utils.heightOf($more, ':before');
   },
 
   placeCaretInTheBeginningOfLine: function(lineNum, cb, waitFor) {
@@ -222,14 +222,14 @@ ep_script_page_view_test_helper.utils = {
     };
 
     var $targetLine = utils.getLine(lineNum);
-    $targetLine.sendkeys("{selectall}{leftarrow}");
+    $targetLine.sendkeys('{selectall}{leftarrow}');
     helper.waitFor(waitFor).done(cb);
   },
 
   placeCaretAtTheEndOfLine: function(lineNum, cb) {
     var utils =  ep_script_page_view_test_helper.utils;
     var $targetLine = utils.getLine(lineNum);
-    $targetLine.sendkeys("{selectall}{rightarrow}");
+    $targetLine.sendkeys('{selectall}{rightarrow}');
     helper.waitFor(function() {
       var $targetLine = utils.getLine(lineNum);
       var $lineWhereCaretIs = utils.getLineWhereCaretIs();
@@ -249,13 +249,13 @@ ep_script_page_view_test_helper.utils = {
   pressKey: function(CODE) {
     var inner$ = helper.padInner$;
     if(inner$(window)[0].bowser.firefox || inner$(window)[0].bowser.modernIE){ // if it's a mozilla or IE
-      var evtType = "keypress";
+      var evtType = 'keypress';
     }else{
-      var evtType = "keydown";
+      var evtType = 'keydown';
     }
     var e = inner$.Event(evtType);
     e.keyCode = CODE;
-    inner$("#innerdocbody").trigger(e);
+    inner$('#innerdocbody').trigger(e);
   },
   pressBackspace: function() {
     var utils = ep_script_page_view_test_helper.utils;
@@ -286,7 +286,7 @@ ep_script_page_view_test_helper.utils = {
     var $targetLine = utils.getLine(lineNumber);
     var targetScrollTop = $targetLine.offset().top;
 
-    var $editor = outer$("#outerdocbody");
+    var $editor = outer$('#outerdocbody');
     $editor.parent().scrollTop(targetScrollTop);
   },
 
@@ -304,7 +304,7 @@ ep_script_page_view_test_helper.utils = {
     // top of the line on pad + shift of inner line
     var expectedScrollTop = $targetLine.offset().top + innerLineShift;
 
-    var $editor = outer$("#outerdocbody");
+    var $editor = outer$('#outerdocbody');
     var actualScrollTop = $editor.parent().scrollTop();
 
     expect(actualScrollTop).to.be.within(expectedScrollTop - acceptedRange, expectedScrollTop + acceptedRange);
@@ -316,7 +316,7 @@ ep_script_page_view_test_helper.utils = {
     var utils = ep_script_page_view_test_helper.utils;
     var outer$ = helper.padOuter$;
 
-    var $editor = outer$("#outerdocbody");
+    var $editor = outer$('#outerdocbody');
 
     var $targetLine = utils.getLine(lineNumberBeforeWaitFor);
     var shiftBetweenTopAndLineWithCaret = $targetLine.offset().top - $editor.parent().scrollTop();
@@ -340,7 +340,7 @@ ep_script_page_view_test_helper.utils = {
   linesAfterNonSplitPageBreaks: function() {
     var inner$ = helper.padInner$;
 
-    var $elementsWithPageBreaksOnBottom = inner$("div nonSplitPageBreak").closest("div");
+    var $elementsWithPageBreaksOnBottom = inner$('div nonSplitPageBreak').closest('div');
     var $linesAfterPageBreaks = $elementsWithPageBreaksOnBottom.next();
 
     return $linesAfterPageBreaks;
@@ -349,7 +349,7 @@ ep_script_page_view_test_helper.utils = {
   linesAfterSplitPageBreaks: function() {
     var inner$ = helper.padInner$;
 
-    var $elementsWithPageBreaksOnBottom = inner$("div splitPageBreak").closest("div");
+    var $elementsWithPageBreaksOnBottom = inner$('div splitPageBreak').closest('div');
     var $linesAfterPageBreaks = $elementsWithPageBreaksOnBottom.next();
 
     return $linesAfterPageBreaks;
@@ -357,7 +357,7 @@ ep_script_page_view_test_helper.utils = {
 
   pageBreakOfLine: function($line) {
     var $lineWithPageBreak = $line.prev();
-    return $lineWithPageBreak.find("nonSplitPageBreak, splitPageBreak").first();
+    return $lineWithPageBreak.find('nonSplitPageBreak, splitPageBreak').first();
   },
 
   getFirstScriptElementOfPageStartingAt: function($lineOnTopOfPage) {
@@ -380,12 +380,12 @@ ep_script_page_view_test_helper.utils = {
       // verify page break is on targetElement
       var $elementsWithPageBreaksOnTop = utils.linesAfterSplitPageBreaks();
       var $firstPageBreak = $elementsWithPageBreaksOnTop.first();
-      var startWithTextAfterPageBreak = new RegExp("^" + textAfterPageBreak);
+      var startWithTextAfterPageBreak = new RegExp('^' + textAfterPageBreak);
       expect(utils.cleanText($firstPageBreak.text())).to.match(startWithTextAfterPageBreak);
 
       // verify page number is correct
-      var $lineWithPageBreak = utils.pageBreakOfLine($firstPageBreak).closest("div");
-      var actualPageNumber = $lineWithPageBreak.find("pagenumber").attr("data-page-number");
+      var $lineWithPageBreak = utils.pageBreakOfLine($firstPageBreak).closest('div');
+      var actualPageNumber = $lineWithPageBreak.find('pagenumber').attr('data-page-number');
       expect(actualPageNumber.toString()).to.be(expectedPageNumber.toString());
 
       done();
@@ -406,8 +406,8 @@ ep_script_page_view_test_helper.utils = {
       // verify page number is correct
       var $elementsWithPageBreaksOnTop = utils.linesAfterNonSplitPageBreaks();
       var $firstPageBreak = $elementsWithPageBreaksOnTop.first();
-      var $lineWithPageBreak = utils.pageBreakOfLine($firstPageBreak).closest("div");
-      var actualPageNumber = $lineWithPageBreak.find("pagenumber").attr("data-page-number");
+      var $lineWithPageBreak = utils.pageBreakOfLine($firstPageBreak).closest('div');
+      var actualPageNumber = $lineWithPageBreak.find('pagenumber').attr('data-page-number');
       expect(actualPageNumber.toString()).to.be(expectedPageNumber.toString());
 
       done();
@@ -420,16 +420,16 @@ ep_script_page_view_test_helper.utils = {
 
     // wait for pagination to be finished
     helper.waitFor(function() {
-      var $splitPageBreaks = inner$("div splitPageBreak");
+      var $splitPageBreaks = inner$('div splitPageBreak');
       var $nonSplitPageBreaks = utils.linesAfterNonSplitPageBreaks();
       return ($splitPageBreaks.length + $nonSplitPageBreaks.length) > 0;
     }, 2000).done(function() {
       // verify there is no MORE tag
-      var $moreTags = inner$("div more");
+      var $moreTags = inner$('div more');
       expect($moreTags.length).to.be(0);
 
       // verify there is no CONT'D tag
-      var $contdTags = inner$("div contd");
+      var $contdTags = inner$('div contd');
       expect($contdTags.length).to.be(0);
 
       done();
@@ -442,20 +442,20 @@ ep_script_page_view_test_helper.utils = {
 
     // wait for pagination to be finished
     helper.waitFor(function() {
-      var $splitPageBreaks = inner$("div splitPageBreak");
+      var $splitPageBreaks = inner$('div splitPageBreak');
       var $nonSplitPageBreaks = utils.linesAfterNonSplitPageBreaks();
       return ($splitPageBreaks.length + $nonSplitPageBreaks.length) > 0;
     }, 2000).done(function() {
       // verify there is a MORE tag
-      var $moreTags = inner$("div more");
+      var $moreTags = inner$('div more');
       expect($moreTags.length).to.be(1);
 
       // verify there is a CONT'D tag
-      var $contdTags = inner$("div contd");
+      var $contdTags = inner$('div contd');
       expect($contdTags.length).to.be(1);
 
       // verify character name is correct
-      var actualCharacterName = $contdTags.first().attr("data-character");
+      var actualCharacterName = $contdTags.first().attr('data-character');
       expect(actualCharacterName).to.be(expectedCharacterName);
 
       done();
@@ -485,7 +485,7 @@ ep_script_page_view_test_helper.utils = {
         var targetLineNumberPosition = ($targetLineNumber.offset() || noLineNumberOffset).top;
         // get inner span position instead of whole div, otherwise test will pass even if
         // behavior is not correct
-        var targetLineOnPadPosition  = $targetLineOnPad.find("span").offset().top;
+        var targetLineOnPadPosition  = $targetLineOnPad.find('span').offset().top;
 
         // get actual heights (relative to origin)
         var actualLineNumberHeight = targetLineNumberPosition - originOfLineNumbers;

--- a/templates/page_view_entry.ejs
+++ b/templates/page_view_entry.ejs
@@ -1,7 +1,0 @@
-<p>
-    <input type="checkbox" id="options-pageview" checked></input>
-</p>
-<p>
-    <input type="checkbox" id="options-pagination" checked></input>
-    <label for="options-pagination" data-l10n-id="ep_script_page_view.pagination">Automatic pagination</label>
-</p>

--- a/templates/page_view_menu.ejs
+++ b/templates/page_view_menu.ejs
@@ -1,2 +1,0 @@
-<li><a id='insertPageBreak'>Page Break</a></li>
-


### PR DESCRIPTION
This is a preparation to implement [the pagination card](https://trello.com/c/dJp83kE0/1971) again.

Cleanup:
- remove all locales, templates, buttons, preferences (not used anymore)
- remove page view enabling/disabling (PV is always 'on');
- remove settings and cookies storages of preferences (use API or URL
instead);
- use single quotes instead of double (code standard);
- use `utils.getPluginProp()` to access
`clientVars.plugins.plugins.ep_script_page_view` more easily. Ideally we
would use the standard `pad.plugins.ep_script_page_view`, but as we
access this var on `aceEditEvent` and `pad.plugins` is not defined since
the pad is loaded, we get some errors that are not priority to be
handled right now;

Features:
- to enable/disable pagination via URL: "pagebreak=true";
- to enable/disable pagination via API:
  { type: 'pagination_enabled', paginationEnabled: true/false }
