### PR TITLE
[feat] Improve speed to calculate page breaks

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -10,7 +10,7 @@
         "acePostWriteDomLineHTML": "ep_script_page_view/static/js/pagination",
         "aceRegisterBlockElements": "ep_script_page_view/static/js/pagination",
         "aceRegisterNonScrollableEditEvents": "ep_script_page_view/static/js/pagination",
-        "collectContentPre": "ep_script_page_view/static/js/paginationSplit",
+        "collectContentPre": "ep_script_page_view/static/js/pagination",
         "aceEditEvent": "ep_script_page_view/static/js/pagination"
       },
       "hooks": {

--- a/static/css/pagination.css
+++ b/static/css/pagination.css
@@ -149,15 +149,16 @@
   }
 
   /* special style used on the calculation of split lines: hide both "()" of cloned parenthetical */
-  /* FIXME do we still need this, after pagination algorithm is changed to not use cloned lines? */
-/*
-  div.clone parenthetical:after,
-  div.clone parenthetical:before {
+  /*
+    FIXME do we still need this, after pagination algorithm is changed to not use cloned lines?
+    Yes! Until we remove calculateHeightToFitText(), at least
+  */
+  #innerdocbody:not(.pasting) div.clone parenthetical:after,
+  #innerdocbody:not(.pasting) div.clone parenthetical:before {
     content: ' ';
     margin-left: 0;
     margin-right: 0;
   }
-*/
 
   /* page number: */
   div pagenumber {

--- a/static/js/cssOptimization.js
+++ b/static/js/cssOptimization.js
@@ -7,6 +7,9 @@ var detailedLinesChangedListener = require('ep_script_scene_marks/static/js/deta
 var BEFORE_PAGE_BREAK_CLASS = 'beforePageBreak';
 var AFTER_PAGE_BREAK_CLASS = 'afterPageBreak';
 
+// warning: these classes are used on other places too
+// TODO use a single constant on utils, instead of the same string across
+// different modules
 var FIRST_HALF_CLASS = 'firstHalf';
 var SECOND_HALF_CLASS = 'secondHalf';
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -30,17 +30,18 @@ var listenToAPICallsToTogglePagination = function() {
 
 var enablePagination = function() {
   togglePagination(true);
-  paginationCalculation.enable();
 }
 
 var disablePagination = function() {
   togglePagination(false);
-  paginationCalculation.disable();
 }
 
 var togglePagination = function(paginationEnabled) {
   utils.getPluginProps().pageBreakEnabled = paginationEnabled;
   utils.getPadInner().find('#innerdocbody').toggleClass('breakPages', paginationEnabled);
+
+  var togglePaginationCalculation = paginationEnabled ? paginationCalculation.enable : paginationCalculation.disable;
+  togglePaginationCalculation();
 }
 
 var adjustToLineNumberSetting = function() {
@@ -71,8 +72,11 @@ var setupPageViewInitialSetting = function() {
 }
 
 var loadPageBreakInitialSettingFromURL = function() {
+  // Pagination is enabled by default, must receive `pagebreak=false` on URL to be disabled
   var urlParams = new URLSearchParams(window.location.search);
-  var paginationEnabled = urlParams.get('pagebreak');
+  var paginationParam = urlParams.get('pagebreak');
+  var paginationEnabled = paginationParam !== 'false';
+
   if (paginationEnabled) {
     enablePagination();
   } else {

--- a/static/js/paginationBlocks.js
+++ b/static/js/paginationBlocks.js
@@ -1,17 +1,18 @@
 var utils = require('./utils');
 var paginationSplit = require('./paginationSplit');
+var lineSizeUtils = require('ep_script_line_size/static/js/utils');
 
-exports.getBlockInfo = function($helperLine) {
-  var $topOfBlock = $helperLine;
+exports.getBlockInfo = function($originalLine) {
+  var $topOfBlock = $originalLine;
 
-  var $previousLine = $helperLine.prev();
-  var $nextLine     = $helperLine.next();
+  var $previousLine = $originalLine.prev();
+  var $nextLine     = $originalLine.next();
 
-  var typeOfCurrentLine  = utils.typeOf($helperLine);
+  var typeOfCurrentLine  = utils.typeOf($originalLine);
   var typeOfPreviousLine = utils.typeOf($previousLine);
   var typeOfNextLine     = utils.typeOf($nextLine);
 
-  var innerLinesOfCurrentLine = getNumberOfInnerLinesOf($helperLine);
+  var innerLinesOfCurrentLine = getNumberOfInnerLinesOf($originalLine);
 
   // block type:
   // (*) => transition (only one line of text)
@@ -104,9 +105,5 @@ exports.getBlockInfo = function($helperLine) {
 }
 
 var getNumberOfInnerLinesOf = function($line) {
-  var totalHeight = utils.getLineHeightWithoutMargins($line);
-  var heightOfOneLine = utils.getRegularLineHeight();
-  var numberOfInnerLines = parseInt(totalHeight / heightOfOneLine);
-
-  return numberOfInnerLines;
+  return lineSizeUtils.getInnerLinesOf($line);
 }

--- a/static/js/paginationLinesChanged.js
+++ b/static/js/paginationLinesChanged.js
@@ -4,16 +4,16 @@ var utils = require('./utils');
 
 var linesChanged = {
   rep: undefined,
-  lines: {},
+  lines: new Set(),
   initialized: false,
 
   add: function(lineNumber) {
-    this.lines[lineNumber] = true;
+    this.lines.add(lineNumber);
   },
 
   reset: function(rep) {
     this.rep = rep;
-    this.lines = {};
+    this.lines.clear();
     this.initialized = true;
   },
 };
@@ -38,13 +38,21 @@ exports.markLineAsChanged = function(lineNumber) {
 }
 
 exports.hasLinesChanged = function() {
-  return _(linesChanged.lines).keys().size > 0;
+  return linesChanged.lines.size > 0;
 }
 
 exports.minLineChanged = function() {
-  return _(_(linesChanged.lines).keys()).min();
+  return _(Array.from(linesChanged.lines)).min();
+}
+
+// same as minLineChanged, but returns the minimum line number ABOVE baseLineNumber
+exports.minLineChangedFromLine = function(baseLineNumber) {
+  var linesAboveBase = _(Array.from(linesChanged.lines)).filter(function(lineNumber) {
+    return lineNumber > baseLineNumber;
+  });
+  return _(linesAboveBase).min();
 }
 
 exports.lineWasChanged = function(lineNumber) {
-  return linesChanged.lines[lineNumber];
+  return linesChanged.lines.has(lineNumber);
 }

--- a/static/js/paginationPageBreaksCalculation.js
+++ b/static/js/paginationPageBreaksCalculation.js
@@ -1,15 +1,17 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 
-var utils                      = require('./utils');
-var paginationBlocks           = require('./paginationBlocks');
-var paginationSplit            = require('./paginationSplit');
-var paginationNonSplit         = require('./paginationNonSplit');
+var utils = require('./utils');
+var paginationBlocks = require('./paginationBlocks');
+var paginationSplit = require('./paginationSplit');
+var paginationNonSplit = require('./paginationNonSplit');
+var paginationPageNumber = require('./paginationPageNumber');
 
-var PAGE_BREAK = paginationNonSplit.PAGE_BREAK_TAG + ',' + paginationSplit.PAGE_BREAK_TAG;
-var DIV_WITH_PAGE_BREAK = 'div:has(' + PAGE_BREAK + ')';
+var lineSizeUtils = require('ep_script_line_size/static/js/utils');
+var lineSizeCalculation = require('ep_script_line_size/static/js/calculation');
 
 var MAX_PAGE_BREAKS_PER_CYCLE = 5;
-var PAGE_BREAK_HEIGHT = 16;
+var FULL_PAGE = utils.LINES_PER_PAGE;
+var LINES_PER_CYCLE = MAX_PAGE_BREAKS_PER_CYCLE * FULL_PAGE;
 
 // initialize with a function that does nothing
 var cleanMarksOnHeadingsOnTopOfPage = function() {};
@@ -17,246 +19,193 @@ exports.setMethodToCleanMarksOnHeadingsOnTopOfPages = function(filterFn) {
   cleanMarksOnHeadingsOnTopOfPage = filterFn;
 }
 
-exports.calculatePageBreaks = function(startLine, originalCaretPosition, attributeManager, rep, performFullPagination) {
+exports.allLinesOfPaginationCycleAreReady = function($lastLineWithPageBreak) {
+  var $linesOfThisCycle = getLinesOfThisPaginationCycle($lastLineWithPageBreak);
+  var $linesWithoutSizeSet = lineSizeUtils.getLinesWithoutSizeSet($linesOfThisCycle);
+  var allLinesReady = $linesWithoutSizeSet.length === 0;
+
+  // make sure lines will have their sizes calculated on the next cycle of pagination
+  if (!allLinesReady) {
+    lineSizeCalculation.calculateInnerLinesOfBlock($linesWithoutSizeSet);
+  }
+
+  return allLinesReady;
+}
+
+var getLinesOfThisPaginationCycle = function($lastLineWithPageBreak) {
+  // filter by non-SMs because LINES_PER_CYCLE does not take into account SMs that might exist
+  // on the pages of this cycle (SMs are ignored by pagination)
+  var $nonSMsOfScript = utils.getPadInner().find('div:not(.sceneMark)');
+
+  var $firstLineAfterLastUnchangedPageBreak = lineAfterUnchangedPageBreak($lastLineWithPageBreak, $nonSMsOfScript);
+  var $firstNonSMAfterLastUnchangedPageBreak = utils.getFirstNonSceneMark($firstLineAfterLastUnchangedPageBreak);
+
+  var indexOfFirstLineOfThisCycle = $nonSMsOfScript.index($firstNonSMAfterLastUnchangedPageBreak);
+  var indexOfLastLineOfThisCycle = indexOfFirstLineOfThisCycle + LINES_PER_CYCLE;
+
+  return $nonSMsOfScript.slice(indexOfFirstLineOfThisCycle, indexOfLastLineOfThisCycle);
+}
+
+exports.calculatePageBreaks = function($lastLineWithPageBreak, firstPageNumberOfThisCycle, originalCaretPosition, attributeManager, rep, performFullPagination) {
   var pageBreaks = [];
+  var nextPageNumber = firstPageNumberOfThisCycle;
 
-  // start paginating only from startLine
+  // start paginating only from $lastLineWithPageBreak
   var $linesOfScript = utils.getPadInner().find('div');
-  var $firstLineAfterLastUnchangedPageBreak = lineAfterUnchangedPageBreak(startLine, $linesOfScript, rep);
+  var $firstLineAfterLastUnchangedPageBreak = lineAfterUnchangedPageBreak($lastLineWithPageBreak, $linesOfScript);
 
-  var $helperLines = createHelperLines($firstLineAfterLastUnchangedPageBreak, $linesOfScript);
-
-  // Bug fix: to be able to get element using its offset, we need to make sure padOuter is
-  // as high as padInner
-  var originalPadInnerHeight = adjustPadInnerHeight();
-
-  var pageBreakInfo = initializePageBreakInfo($helperLines);
-
+  var pageBreakInfo = initializePageBreakInfo($firstLineAfterLastUnchangedPageBreak);
   var lineNumberShift = 0;
+
   while(!reachedEndOfPad(pageBreakInfo) &&
         !foundEnoughPageBreaksForThisCycle(pageBreaks, performFullPagination)) {
 
     lineNumberShift -= getNumberOfMergedLinesOnPage(pageBreakInfo);
 
-    var availableHeightOnPageWithoutMargins = pageBreakInfo.offsetAtBeginningOfNextPage.top -
-                                              pageBreakInfo.$firstLineOfNextPage.offset().top;
-    var $originalLine = getOriginalLineFromHelperLine(pageBreakInfo.$firstLineOfNextPage, $linesOfScript);
+    // line might have a marginTop, so we cannot consider it on the available space
+    var pageHasOnlyOneLine = pageBreakInfo.linesOnNextPage === 1;
+    var marginTop = pageHasOnlyOneLine ? 0 : lineSizeUtils.getMarginOf(pageBreakInfo.$firstLineOfNextPage);
+    var linesAvailableBeforePageBreak = pageBreakInfo.linesAvailableBeforePageBreak - marginTop;
 
-    var splitLineInfo = paginationSplit.getSplitInfo(pageBreakInfo.$firstLineOfNextPage, $originalLine, lineNumberShift, availableHeightOnPageWithoutMargins, originalCaretPosition, attributeManager, rep);
+    var splitLineInfo = paginationSplit.getSplitInfo(pageBreakInfo.$firstLineOfNextPage, lineNumberShift, linesAvailableBeforePageBreak, originalCaretPosition, attributeManager, rep);
     var lineCanBeSplit = !! splitLineInfo;
 
     if (lineCanBeSplit) {
-      // move offset of next page to first inner line of the 2nd half of the split
-      var heightOfFirstHalf = splitLineInfo.innerLinesOnFirstHalf * utils.getRegularLineHeight();
-      var offsetOfSecondHalf = increaseOffsetTop(pageBreakInfo.$firstLineOfNextPage.offset(), heightOfFirstHalf);
-      pageBreakInfo.offsetAtBeginningOfNextPage = offsetOfSecondHalf;
-
       // mark line to be split
-      pageBreaks.push(splitPageBreak(splitLineInfo, pageBreakInfo.$firstLineOfNextPage, $linesOfScript, rep));
+      pageBreaks.push(splitPageBreak(splitLineInfo, nextPageNumber, pageBreakInfo.$firstLineOfNextPage, $linesOfScript, rep));
 
-      // there will be an extra line from now on
-      lineNumberShift++;
+      if (!splitLineInfo.skipPagination) {
+        // there will be an extra line from now on -- if pagination is not skipped
+        lineNumberShift++;
+      }
     } else {
       // it is a block of lines (a block can have only a single line too)
       var blockInfo = paginationBlocks.getBlockInfo(pageBreakInfo.$firstLineOfNextPage);
-
-      // move offset of next page to first script element of it (ignore scene marks)
-      pageBreakInfo.offsetAtBeginningOfNextPage = blockInfo.$topOfBlock.offset();
 
       // we cannot have a page break between a heading and its act/seq.
       // Move $topOfBlock up if this happens, otherwise just use original $topOfBlock
       pageBreakInfo.$firstLineOfNextPage = utils.getTopSceneMarkOrTargetLine(blockInfo.$topOfBlock);
 
       // mark line to be on top of page
-      pageBreaks.push(nonSplitPageBreak(pageBreakInfo.$firstLineOfNextPage, $linesOfScript, lineNumberShift, rep));
+      pageBreaks.push(nonSplitPageBreak(nextPageNumber, pageBreakInfo.$firstLineOfNextPage, $linesOfScript, lineNumberShift, rep));
     }
 
-    pageBreakInfo = getNextPageBreakInfo(pageBreakInfo, $helperLines);
+    pageBreakInfo = getNextPageBreakInfo(pageBreakInfo, splitLineInfo);
+    nextPageNumber++;
   }
-
-  removeHelperLines($helperLines);
 
   return {
     done: !foundEnoughPageBreaksForThisCycle(pageBreaks, performFullPagination),
+    reachedPointWherePaginationAlreadyExist: reachedPointWherePaginationAlreadyExist(pageBreaks),
     pageBreaksInfo: pageBreaks,
   };
 }
 
-// alias to get page height
-var fullPage = utils.getMaxPageHeight;
-
-var initializePageBreakInfo = function($helperLines) {
-  var $firstLineOfThisPage        = $helperLines.first();
-  var offsetAtBeginningOfNextPage = getOffsetOfNextPage($firstLineOfThisPage.offset());
-  var $firstLineOfNextPage        = $helperLines.filter(getLineAt(offsetAtBeginningOfNextPage));
+var initializePageBreakInfo = function($firstLineOfThisPage) {
+  var sizeOfLineOnTopOfPage = lineSizeUtils.getInnerLinesOf($firstLineOfThisPage);
+  var infoOfNextPage = getInfoOfNextPage($firstLineOfThisPage, sizeOfLineOnTopOfPage);
 
   return {
-    offsetAtBeginningOfNextPage: offsetAtBeginningOfNextPage,
     $firstLineOfThisPage: $firstLineOfThisPage,
-    $firstLineOfNextPage: $firstLineOfNextPage,
+    $firstLineOfNextPage: infoOfNextPage.$firstLineOfNextPage,
+    linesAvailableBeforePageBreak: infoOfNextPage.linesAvailableBeforePageBreak,
+    linesOnNextPage: infoOfNextPage.linesOnNextPage,
   };
 }
 
-var getNextPageBreakInfo = function(pageBreakInfo, $helperLines) {
-  var $firstLineOfThisPage        = pageBreakInfo.$firstLineOfNextPage;
-  var offsetAtBeginningOfNextPage = getOffsetOfNextPage(pageBreakInfo.offsetAtBeginningOfNextPage);
-  var $firstLineOfNextPage        = $helperLines.filter(getLineAt(offsetAtBeginningOfNextPage));
+var getNextPageBreakInfo = function(pageBreakInfo, splitLineInfo) {
+  var $firstLineOfThisPage = pageBreakInfo.$firstLineOfNextPage;
+  // linesUsedByPreviousPagination: if previous pageBreak is a split line, the space
+  // used by 2nd half of split line is not available for next page
+  var linesUsedByPreviousPagination = splitLineInfo ? splitLineInfo.innerLinesOnSecondHalf : 0;
+
+  // when we're re-splitting a split line, $firstLineOfThisPage points to the
+  // 1st half of the split -- this is a convenience to make it easier to calculate
+  // the point of a split line. But in this case the actual line on top of page is
+  // the 2nd half, so we need to make some adjustments to $firstLineOfThisPage
+  var splitLineWillBeReSplit = splitLineInfo && $firstLineOfThisPage.is('.firstHalf');
+  if (splitLineWillBeReSplit) {
+    // move to the 2nd half
+    $firstLineOfThisPage = $firstLineOfThisPage.next();
+  }
+
+  // if there's no size calculated on previous pagination, use the default method (getInnerLinesOf)
+  var sizeOfLineOnTopOfPage = linesUsedByPreviousPagination || lineSizeUtils.getInnerLinesOf($firstLineOfThisPage);
+  var infoOfNextPage = getInfoOfNextPage($firstLineOfThisPage, sizeOfLineOnTopOfPage);
 
   return {
-    offsetAtBeginningOfNextPage: offsetAtBeginningOfNextPage,
     $firstLineOfThisPage: $firstLineOfThisPage,
-    $firstLineOfNextPage: $firstLineOfNextPage,
+    $firstLineOfNextPage: infoOfNextPage.$firstLineOfNextPage,
+    linesAvailableBeforePageBreak: infoOfNextPage.linesAvailableBeforePageBreak,
+    linesOnNextPage: infoOfNextPage.linesOnNextPage,
   };
 }
 
-var getOffsetOfNextPage = function(currentOffset) {
-  var topShift = fullPage();
-  return increaseOffsetTop(currentOffset, topShift);
-}
+var getInfoOfNextPage = function($firstLineOfThisPage, sizeOfLineOnTopOfPage) {
+  var linesAvailable = FULL_PAGE;
 
-var increaseOffsetTop = function(offset, topShift) {
-  var newTop = offset.top + topShift;
-  return { top: newTop, left: offset.left }
+  // BUGFIX when a SM is on top of a page, its heading won't be shown with a margin,
+  // but it is stored as if it does because there are some lines between it and the
+  // top of the page -- its own SMs. To workaround this scenario, we adjust
+  // linesAvailable
+  if (utils.isSceneMark($firstLineOfThisPage)) linesAvailable += 2;
+
+  var $nextLine = $firstLineOfThisPage;
+  var sizeOfNextLine = sizeOfLineOnTopOfPage;
+  var linesOnNextPage = 0;
+
+  // move down on pad until we find a line that does not fit on this page
+  while (linesAvailable >= sizeOfNextLine) {
+    // $nextLine fits on this page, so move to the next one
+    linesAvailable -= sizeOfNextLine;
+    $nextLine = $nextLine.next();
+    sizeOfNextLine = lineSizeUtils.getFullSizeOf($nextLine);
+    linesOnNextPage++;
+
+    // reached the end of pad and all lines fit on this page.
+    // Don't need to look further
+    if ($nextLine.length === 0) break;
+  }
+
+  return {
+    $firstLineOfNextPage: $nextLine,
+    linesAvailableBeforePageBreak: linesAvailable,
+    linesOnNextPage: linesOnNextPage || 1,
+  }
 }
 
 var getNumberOfMergedLinesOnPage = function(pageBreakInfo) {
   var $linesOfThisPage = pageBreakInfo.$firstLineOfThisPage.nextUntil(pageBreakInfo.$firstLineOfNextPage).andSelf();
-  var $mergedLinesOfThisPage = $linesOfThisPage.filter('.' + paginationSplit.MERGED_LINE);
+  // TODO we need to be more cautious here: maybe the 2nd half was removed.
+  // use paginationSplit.linesAreHalvesOfSameSplit() to check which lines are valid
+  // 1st halves of a split line
+  var $mergedLinesOfThisPage = $linesOfThisPage.filter('.firstHalf');
   return $mergedLinesOfThisPage.length;
 }
 
-var adjustPadInnerHeight = function() {
-  var padInnerFrame = utils.getPadOuter().find("iframe[name='ace_inner']");
-  var originalHeight = parseInt(padInnerFrame.css('height'));
-
-  // change pad inner css to force pad outer to adjust
-  var heightWithHelperLines = utils.getPadInner().height();
-  padInnerFrame.css('height', heightWithHelperLines.toString() + 'px');
-
-  return originalHeight;
-}
-
-var createHelperLines = function($firstLine, $linesOfScript) {
-  var $lastLineOfScript      = $linesOfScript.last();
-  var startAtOffset          = $firstLine.offset();
-  var firstLineToNotBeCloned = getFirstLineNotReachedByThisPaginationCycle(startAtOffset);
-  var $linesToClone          = $firstLine.nextUntil(firstLineToNotBeCloned).andSelf();
-  var $helperLines           = createCleanClonesOf($linesToClone);
-
-  $helperLines.insertAfter($lastLineOfScript);
-
-  // Bug fix: mark first visible helper line to have no margin top.
-  // This is necessary because first line is originally on top of a page
-  // (so without any margin), but when it is cloned it is added after a
-  // regular line (so it would have a margin)
-  adjustFirstVisibleHelperLine($helperLines);
-
-  return $helperLines;
-}
-
-var getFirstLineNotReachedByThisPaginationCycle = function(startAtOffset) {
-  var endAtOffsetTop   = startAtOffset.top + getTotalHeightOfPaginationCycle();
-  var endAtOffset      = { top: Math.ceil(endAtOffsetTop), left: Math.ceil(startAtOffset.left) };
-  var $lineAtEndOffset = getLineAt(endAtOffset);
-
-  return $lineAtEndOffset.get(0);
-}
-
-var getLineAt = function(offset) {
-  var editorDocument  = utils.getPadOuter().find("iframe[name='ace_inner']").get(0).contentDocument;
-  var elementAtOffset = editorDocument.elementFromPoint(offset.left, offset.top);
-  var $lineAtOffset = $(elementAtOffset).closest('div');
-
-  // offset might be at a margin, so try next line
-  if ($lineAtOffset.length === 0) {
-    var oneLine = utils.getHeightOfOneLine();
-    elementAtOffset = editorDocument.elementFromPoint(offset.left, offset.top + oneLine);
-    $lineAtOffset = $(elementAtOffset).closest('div');
-
-    // headings have 2-lines margin, so it's possible that we still didn't reach its content
-    if ($lineAtOffset.length === 0) {
-      elementAtOffset = editorDocument.elementFromPoint(offset.left, offset.top + 2*oneLine);
-      $lineAtOffset = $(elementAtOffset).closest('div');
-    }
-  }
-
-  return $lineAtOffset;
-}
-
-var createCleanClonesOf = function($lines) {
-  var $cleanCopies = $lines.clone();
-  $cleanCopies = doNotConsiderSceneMarksOf($cleanCopies);
-  $cleanCopies = paginationSplit.mergeHelperLines($cleanCopies);
-  utils.cleanHelperLines($cleanCopies);
-
-  return $cleanCopies;
-}
-
-var adjustFirstVisibleHelperLine = function($helperLines) {
-  var $visibleHelperLines = $helperLines.filter(':not(.sceneMark)');
-  var $firstVisibleLine = $visibleHelperLines.first();
-  $firstVisibleLine.addClass('cloned__first');
-}
-
-var doNotConsiderSceneMarksOf = function($lines) {
-  // we cannot remove scene marks because they are used later to calculate page break,
-  // but we can hide them, as they should not be counted on page height calculation
-  $lines.filter('.sceneMark').height(0);
-
-  // headings with scene marks on top of page are manually marked with a class to
-  // not have top margins, but when we're paginating this mark should be ignored, as those
-  // headings might be in the middle of a page after re-pagination finishes
-  cleanMarksOnHeadingsOnTopOfPage($lines);
-
-  return $lines;
-}
-
-var removeHelperLines = function($helperLines) {
-  $helperLines.remove();
-}
-
-var getTotalHeightOfPaginationCycle = function() {
-  return MAX_PAGE_BREAKS_PER_CYCLE * (
-    // height of one page
-    fullPage() +
-    // height of page break
-    PAGE_BREAK_HEIGHT +
-    // assuming worst case: all page breaks have MORE/CONT'D and all of them have a split line
-    // which resulted in 2 halves that are 1 line higher than the unsplit line
-    3 * utils.getHeightOfOneLine() // (1 for MORE, 1 for CONT'D and 1 for extra line due to split)
-  );
-}
-
-var getOriginalLineFromHelperLine = function($helperLine, $linesOfScript) {
-  var lineId = $helperLine.attr('data-original-id');
-  var $originalLine = $linesOfScript.filter('#'+lineId);
-
-  return $originalLine;
-}
-
-var nonSplitPageBreak = function($helperLine, $linesOfScript, lineNumberShift, rep) {
-  var $originalLine = getOriginalLineFromHelperLine($helperLine, $linesOfScript);
-
+var nonSplitPageBreak = function(pageNumber, $originalLine, $linesOfScript, lineNumberShift, rep) {
   var nonSplitInfo = paginationNonSplit.getNonSplitInfo($originalLine, lineNumberShift, rep);
   return {
     data: nonSplitInfo,
+    pageNumber: pageNumber,
     lineNumberBeforeClean: nonSplitInfo.lineNumberBeforeClean,
     lineNumberAfterClean: nonSplitInfo.lineNumberAfterClean,
-    save: function(data, pageNumber, attributeManager, rep, editorInfo) {
-      paginationNonSplit.savePageBreak(data, pageNumber, attributeManager);
+    save: function(data, attributeManager, rep, editorInfo) {
+      paginationNonSplit.savePageBreak(data, attributeManager);
+      paginationPageNumber.savePageBreak(data, pageNumber, attributeManager);
       nonSplitInfo.callbackAfterSave(attributeManager);
     }
   };
 }
-var splitPageBreak = function(splitInfo, $helperLine, $linesOfScript, rep) {
-  var $originalLine = getOriginalLineFromHelperLine($helperLine, $linesOfScript);
-
+var splitPageBreak = function(splitInfo, pageNumber, $originalLine, $linesOfScript, rep) {
   return {
     data: splitInfo,
+    pageNumber: pageNumber,
     lineNumberBeforeClean: utils.getLineNumberFromDOMLine($originalLine, rep),
     lineNumberAfterClean: splitInfo.lineNumberAfterClean,
-    save: function(data, pageNumber, attributeManager, rep, editorInfo) {
-      paginationSplit.savePageBreak(data, pageNumber, attributeManager, editorInfo, rep);
+    save: function(data, attributeManager, rep, editorInfo) {
+      paginationSplit.savePageBreak(data, attributeManager, editorInfo, rep);
+      paginationPageNumber.savePageBreak(data, pageNumber, attributeManager);
     }
   };
 }
@@ -272,17 +221,23 @@ var foundEnoughPageBreaksForThisCycle = function(pageBreaks, performFullPaginati
   return pageBreaks.length === MAX_PAGE_BREAKS_PER_CYCLE;
 }
 
-var lineAfterUnchangedPageBreak = function(startLine, $linesOfScript, rep) {
+var lineAfterUnchangedPageBreak = function($lastLineWithPageBreak, $linesOfScript) {
   var $lineAfterPageBreak;
 
-  var $startLine = $(utils.getDOMLineFromLineNumber(startLine, rep));
-  var $linesWithPageBreaks = $startLine.prevAll(DIV_WITH_PAGE_BREAK);
-  if ($linesWithPageBreaks.length === 0) {
-    // pad does not have any page break before startLine, get all lines
+  if ($lastLineWithPageBreak.length === 0) {
+    // pad does not have any page break, get all lines
     $lineAfterPageBreak = $linesOfScript.first();
   } else {
-    $lineAfterPageBreak = $linesWithPageBreaks.first().next();
+    $lineAfterPageBreak = $lastLineWithPageBreak.next();
   }
 
   return $lineAfterPageBreak;
+}
+
+// if the last page break is already at a point where the pagination exist,
+// the changes of this cycle won't affect pagination of lines after the
+// lines affected by this cycle
+var reachedPointWherePaginationAlreadyExist = function(pageBreaks) {
+  var lastPageBreak = pageBreaks[pageBreaks.length - 1];
+  return lastPageBreak && lastPageBreak.data.skipPagination;
 }

--- a/static/js/paginationPageNumber.js
+++ b/static/js/paginationPageNumber.js
@@ -3,8 +3,9 @@ var utils = require('./utils');
 var PAGE_NUMBER_ATTRIB = 'pageNumber';
 exports.PAGE_NUMBER_ATTRIB = PAGE_NUMBER_ATTRIB;
 
-exports.cleanPageBreaks = function(startAtLine, endAtLine, attributeManager) {
-  for (var lineNumber = endAtLine; lineNumber >= startAtLine; lineNumber--) {
+exports.cleanPageBreaks = function(linesToBeCleared, attributeManager) {
+  for (var i = linesToBeCleared.length - 1; i >= 0; i--) {
+    var lineNumber = linesToBeCleared[i];
     // remove marker of page number
     if (lineHasPageNumberMarker(lineNumber, attributeManager)) {
       removePageNumberFrom(lineNumber, attributeManager);
@@ -12,16 +13,52 @@ exports.cleanPageBreaks = function(startAtLine, endAtLine, attributeManager) {
   }
 }
 
-exports.savePageBreak = function(lineNumber, pageNumber, attributeManager) {
-  attributeManager.setAttributeOnLine(lineNumber, PAGE_NUMBER_ATTRIB, pageNumber);
+exports.savePageBreak = function(pageBreakInfo, pageNumber, attributeManager) {
+  // although the pagination might be at the same spot on text, the page number
+  // might have changed, so we need to check for that too (ex: user removes a full
+  // page => page breaks will be at the same places, but all page numbers will
+  // be decremented by 1)
+  if (!pageBreakInfo.skipPagination || pageNumberChanged(pageBreakInfo, pageNumber, attributeManager)) {
+    var lineNumber = pageBreakInfo.lineNumberAfterClean;
+    setPageNumberOnLine(lineNumber, pageNumber, attributeManager);
+  }
+}
+
+var pageNumberChanged = function(pageBreakInfo, nextPageNumber, attributeManager) {
+  var lineNumber = pageBreakInfo.lineNumberAfterClean;
+  var currentPageNumber = getPageNumberOfLine(lineNumber, attributeManager);
+  return currentPageNumber.toString() !== nextPageNumber.toString();
 }
 
 var lineHasPageNumberMarker = function(lineNumber, attributeManager) {
+  return !!getPageNumberOfLine(lineNumber, attributeManager);
+}
+
+var getPageNumberOfLine = function(lineNumber, attributeManager) {
   return attributeManager.getAttributeOnLine(lineNumber, PAGE_NUMBER_ATTRIB);
+}
+
+var setPageNumberOnLine = function(lineNumber, pageNumber, attributeManager) {
+  attributeManager.setAttributeOnLine(lineNumber, PAGE_NUMBER_ATTRIB, pageNumber);
 }
 
 var removePageNumberFrom = function(lineNumber, attributeManager) {
   attributeManager.removeAttributeOnLine(lineNumber, PAGE_NUMBER_ATTRIB);
+}
+
+// for each line on $linesWithPageBreaks, make sure its page number is correct.
+// $linesWithPageBreaks[0] should have pageNumber === lastPageNumber;
+// $linesWithPageBreaks[1] should have pageNumber === lastPageNumber + 1;
+// etc.
+exports.ensurePageNumbersAreCorrectAfterLine = function($linesWithPageBreaks, lastPageNumber, attributeManager, rep) {
+  for (var i = 0; i < $linesWithPageBreaks.length; i++) {
+    var thisPageNumber = lastPageNumber + i;
+    var $thisLine = $linesWithPageBreaks.eq(i);
+    var thisLineNumber = utils.getLineNumberFromDOMLine($thisLine, rep);
+    if (pageNumberChanged(thisLineNumber, thisPageNumber, attributeManager)) {
+      setPageNumberOnLine(thisLineNumber, thisPageNumber, attributeManager);
+    }
+  }
 }
 
 exports.atribsToClasses = function(context) {

--- a/static/tests/frontend/specs/basicPagination.js
+++ b/static/tests/frontend/specs/basicPagination.js
@@ -18,7 +18,7 @@ var DIALOGUES_PER_PAGE      = 58;
 var TRANSITIONS_PER_PAGE    = 28;
 var SHOTS_PER_PAGE          = 20;
 
-describe.skip('ep_script_page_view - pagination basic tests', function() {
+describe('ep_script_page_view - pagination basic tests', function() {
   var utils, pageBreak;
 
   var getPageBuilder = function(elementsPerPage, builder) {
@@ -36,7 +36,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
   context('when lines do not have any top or bottom margin', function() {
     before(function(done) {
       var scriptBuilder = pageBreak.scriptWithPageFullOfGenerals;
-      pageBreak.createScript(scriptBuilder, done);
+      pageBreak.createScript(this, scriptBuilder, done);
     });
 
     it('fits ' + GENERALS_PER_PAGE + ' lines in a page', function(done) {
@@ -72,7 +72,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
       before(function(done) {
         var test = this;
         var scriptBuilder = getPageBuilder(HEADINGS_PER_PAGE, utils.heading);
-        pageBreak.createScript(scriptBuilder, function() {
+        pageBreak.createScript(this, scriptBuilder, function() {
           var elementBuilder = utils.heading;
           var pageBuilder    = getPageBuilder(HEADINGS_PER_PAGE, elementBuilder);
           pageBreak.prepareScriptToTestIfItFitsXLinesPerPage(elementBuilder, pageBuilder, test, done);
@@ -142,7 +142,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
           helper.waitFor(function() {
             var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
             return $linesWithPageBreaks.length === 2;
-          }).done(function() {
+          }, 2000).done(function() {
             var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
             // $linesWithPageBreaks are all synopsis, need to get first heading after them
             var $firstLineOfThirdPage = utils.getFirstScriptElementOfPageStartingAt($linesWithPageBreaks.last());
@@ -158,7 +158,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
     context('and all lines are actions', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(ACTIONS_PER_PAGE, utils.action);
-        pageBreak.createScript(scriptBuilder, done);
+        pageBreak.createScript(this, scriptBuilder, done);
       });
 
       it('fits ' + ACTIONS_PER_PAGE + ' lines in a page', function(done) {
@@ -171,7 +171,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
     context('and all lines are characters', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(CHARACTERS_PER_PAGE, utils.character);
-        pageBreak.createScript(scriptBuilder, done);
+        pageBreak.createScript(this, scriptBuilder, done);
       });
 
       it('fits ' + CHARACTERS_PER_PAGE + ' lines in a page', function(done) {
@@ -184,7 +184,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
     context('and all lines are parentheticals', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(PARENTHETICALS_PER_PAGE, utils.parenthetical);
-        pageBreak.createScript(scriptBuilder, done);
+        pageBreak.createScript(this, scriptBuilder, done);
       });
 
       it('fits ' + PARENTHETICALS_PER_PAGE + ' lines in a page', function(done) {
@@ -197,7 +197,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
     context('and all lines are dialogues', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(DIALOGUES_PER_PAGE, utils.dialogue);
-        pageBreak.createScript(scriptBuilder, done);
+        pageBreak.createScript(this, scriptBuilder, done);
       });
 
       it('fits ' + DIALOGUES_PER_PAGE + ' lines in a page', function(done) {
@@ -210,7 +210,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
     context('and all lines are transitions', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(TRANSITIONS_PER_PAGE, utils.transition);
-        pageBreak.createScript(scriptBuilder, done);
+        pageBreak.createScript(this, scriptBuilder, done);
       });
 
       it('fits ' + TRANSITIONS_PER_PAGE + ' lines in a page', function(done) {
@@ -223,7 +223,7 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
     context('and all lines are shots', function() {
       before(function(done) {
         var scriptBuilder = getPageBuilder(SHOTS_PER_PAGE, utils.shot);
-        pageBreak.createScript(scriptBuilder, done);
+        pageBreak.createScript(this, scriptBuilder, done);
       });
 
       it('fits ' + SHOTS_PER_PAGE + ' lines in a page', function(done) {
@@ -237,9 +237,11 @@ describe.skip('ep_script_page_view - pagination basic tests', function() {
 
 var ep_script_page_view_test_helper = ep_script_page_view_test_helper || {};
 ep_script_page_view_test_helper.pageBreak = {
-  createScript: function(builder, done) {
+  createScript: function(test, builder, done) {
     var self = this;
     var utils = ep_script_page_view_test_helper.utils;
+
+    test.timeout(5000);
 
     utils.cleanPad(function() {
       utils.createScriptWith(builder('1st page'), '1st page', function() {
@@ -280,7 +282,7 @@ ep_script_page_view_test_helper.pageBreak = {
   },
 
   prepareScriptToTestIfItFitsXLinesPerPage: function(elementBuilder, pageBuilder, test, done) {
-    test.timeout(5000);
+    test.timeout(6000);
 
     var inner$ = helper.padInner$;
     var utils = ep_script_page_view_test_helper.utils;
@@ -302,7 +304,7 @@ ep_script_page_view_test_helper.pageBreak = {
     helper.waitFor(function() {
       var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
       return $linesWithPageBreaks.length === 2;
-    }, 3000).done(done);
+    }, 5000).done(done);
   },
 
   checkIfItFitsXLinesPerPage: function(done) {

--- a/static/tests/frontend/specs/calculatingPageNumber.js
+++ b/static/tests/frontend/specs/calculatingPageNumber.js
@@ -1,57 +1,59 @@
-describe.skip('ep_script_page_view - calculating page number', function() {
-  var utils;
+describe('ep_script_page_view - calculating page number', function() {
+  var utils = ep_script_page_view_test_helper.utils;
 
-  before(function(){
-    utils = ep_script_page_view_test_helper.utils;
-  });
+  var MAX_PAGE_BREAKS_PER_CYCLE = 5;
 
-  beforeEach(function(done){
+  // build script with lots of pages, so repagination takes a while to finish
+  var NUMBER_OF_PAGES = 12;
+
+  // create pad and wait for its lines to have the size calculated
+  before(function(done) {
     helper.newPad(function() {
-      utils.cleanPad(done);
+      utils.cleanPad(function() {
+        var lastLineText = 'general';
+
+        // each page has several single-line generals, and last line is a two-lines general
+        // (so it is split later)
+        var line1 = utils.buildStringWithLength(50, '1') + '. ';
+        var line2 = utils.buildStringWithLength(50, '2') + '. ';
+        var fullPage = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE - 2) +
+                       utils.general(line1 + line2);
+        var lastLine = utils.general(lastLineText);
+        var script = utils.buildStringWithLength(NUMBER_OF_PAGES, fullPage) + lastLine;
+        utils.createScriptWith(script, lastLineText, function() {
+          // wait for all lines to have size calculated (this takes a long time for large pads)
+          helper.waitFor(function() {
+            return ep_script_line_size_test_helper.utils.allLinesHaveSize();
+          }, 40000).done(function() {
+            // wait for initial pagination to finish
+            utils.waitToHaveNNonSplitPageBreaks(NUMBER_OF_PAGES, done);
+          });
+        });
+      });
     });
     this.timeout(60000);
   });
 
   context('when repagination is running and page number was not recalculated yet', function() {
-    var MAX_PAGE_BREAKS_PER_CYCLE = 5;
+    before(function(done) {
+      this.timeout(20000);
 
-    // build script with lots of pages, so repagination takes a while to finish
-    var NUMBER_OF_PAGES = 22;
-
-    beforeEach(function(done) {
-      this.timeout(14000);
+      // slow down pagination, so we can have more reliable tests
+      utils.setPaginationDelay(1000);
 
       var inner$ = helper.padInner$;
 
-      var lastLineText = 'general';
+      // inserts a long text to first line, so all lines will be shift one line down
+      // and pagination will change scroll position of elements
+      var longText = utils.buildStringWithLength(62, '1');
+      var $firstLine = inner$('div span').first();
+      $firstLine.sendkeys(longText);
 
-      // each page has several single-line generals, and last line is a two-lines general
-      // (so it is split later)
-      var line1 = utils.buildStringWithLength(50, '1') + '. ';
-      var line2 = utils.buildStringWithLength(50, '2') + '. ';
-      var fullPage = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE - 2) +
-                     utils.general(line1 + line2);
-      var lastLine = utils.general(lastLineText);
-      var script = utils.buildStringWithLength(NUMBER_OF_PAGES, fullPage) + lastLine;
-      utils.createScriptWith(script, lastLineText, function() {
-        // wait for initial pagination to finish
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length === NUMBER_OF_PAGES;
-        }, 10000).done(function() {
-          // inserts a long text to first line, so all lines will be shift one line down
-          // and pagination will change scroll position of elements
-          var longText = utils.buildStringWithLength(62, '1');
-          var $firstLine = inner$('div').first();
-          $firstLine.sendkeys(longText);
-
-          // wait for first cycle of repagination to be completed before start testing
-          helper.waitFor(function() {
-            var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-            return $linesWithPageBreaks.length > 1;
-          }, 2000).done(done);
-        });
-      });
+      // wait for first cycle of repagination to be completed before start testing
+      helper.waitFor(function() {
+        var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
+        return $linesWithPageBreaks.length > 1;
+      }, 5000).done(done);
     });
 
     it('displays a loading icon beside page number value', function(done) {
@@ -69,15 +71,11 @@ describe.skip('ep_script_page_view - calculating page number', function() {
     });
 
     context('and repagination is complete', function() {
-
-      beforeEach(function(done) {
+      before(function(done) {
         this.timeout(10000);
-
-        // wait for repagination to finish
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-          return $linesWithPageBreaks.length === NUMBER_OF_PAGES;
-        }, 10000).done(done);
+        // speed up pagination, as now we only need to wait for it to finish
+        utils.speedUpPagination();
+        utils.waitToHaveNSplitPageBreaks(NUMBER_OF_PAGES, done);
       });
 
       it('does not display a loading icon beside page number value', function(done) {

--- a/static/tests/frontend/specs/elementBlocks.js
+++ b/static/tests/frontend/specs/elementBlocks.js
@@ -3,7 +3,7 @@
 // A4
 var GENERALS_PER_PAGE = 58;
 
-describe.skip('ep_script_page_view - pagination of element blocks', function() {
+describe('ep_script_page_view - pagination of element blocks', function() {
   var utils;
 
   var undoLastChanges = function(done) {
@@ -95,7 +95,7 @@ describe.skip('ep_script_page_view - pagination of element blocks', function() {
   }
 
   var createBaseScript = function(test, done) {
-    test.timeout(5000);
+    test.timeout(15000);
 
     utils.cleanPad(function() {
       var act         = utils.act('first act', 'summary of act');
@@ -105,7 +105,11 @@ describe.skip('ep_script_page_view - pagination of element blocks', function() {
       var generals    = utils.buildScriptWithGenerals('general', GENERALS_PER_PAGE);
       var lastGeneral = utils.general('last general');
       var script      = act + seq + synopsis + heading + generals + lastGeneral;
-      utils.createScriptWith(script, 'last general', done);
+      utils.createScriptWith(script, 'last general', function() {
+        // make sure the first pagination runs, otherwise we might have some
+        // errors on script creation
+        utils.waitToHaveAnyPageBreak(done);
+      });
     });
   }
 

--- a/static/tests/frontend/specs/enablePagination.js
+++ b/static/tests/frontend/specs/enablePagination.js
@@ -1,4 +1,4 @@
-describe.skip('ep_script_page_view - Enable / Disable automatic pagination', function() {
+describe('ep_script_page_view - Enable / Disable automatic pagination', function() {
   var NUMBER_OF_PAGES = 3;
   var SHOULD_HAVE_PAGE_BREAK = true;
   var SHOULD_NOT_HAVE_PAGE_BREAK = false;
@@ -9,7 +9,7 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
     helper.waitFor(function() {
       var scriptHasPageBreaks = utils.linesAfterNonSplitPageBreaks().length > 0;
       return scriptHasPageBreaks === shouldHavePageBreak;
-    }).done(done);
+    }, 10000).done(done);
   }
   var makeSurePageBreaksWereAdded = function(done) {
     waitForPageBreaksChange(SHOULD_HAVE_PAGE_BREAK, done);
@@ -39,6 +39,7 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
 
   context('when script has page breaks and user disables pagination', function() {
     before(function(done) {
+      this.timeout(10000);
       utils.enablePagination();
 
       makeSurePageBreaksWereAdded(function() {
@@ -48,12 +49,14 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
     });
 
     it('removes all page breaks', function(done) {
+      this.timeout(5000);
       makeSurePageBreaksWereRemoved(done);
     });
   });
 
   context('when script has no page breaks and user enables pagination', function() {
     before(function(done) {
+      this.timeout(5000);
       utils.disablePagination();
 
       makeSurePageBreaksWereRemoved(function() {
@@ -74,14 +77,8 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
       makeSurePageBreaksWereAdded(function() {
         // wait for page breaks to be saved
         setTimeout(function() {
-          // load another pad, so can disable pagination without affecting page breaks of
-          // original pad
-          helper.newPad(function() {
-            utils.disablePagination();
-
-            // load original pad, the one with page breaks
-            helper.newPad(done, padId);
-          });
+          // reload pad, but with pagination flag off
+          helper.newPad(done, `${padId}?pagebreak=false`);
         }, 1000);
       });
 
@@ -89,35 +86,8 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
     });
 
     it('removes all page breaks', function(done) {
+      this.timeout(5000);
       makeSurePageBreaksWereRemoved(done);
-    });
-  });
-
-  context('when pagination is enabled on preferences by the user', function() {
-    before(function() {
-      utils.enablePagination();
-    });
-
-    it('reloads original pad with pagination disabled', function(done) {
-      // reload same pad
-      helper.newPad(function() {
-        var $paginationSetting = helper.padChrome$('#options-pagination');
-        expect($paginationSetting.prop('checked')).to.be(false);
-        done();
-      }, padId);
-
-      this.timeout(60000);
-    });
-
-    it('loads new pads with pagination disabled', function(done) {
-      // load a new pad
-      helper.newPad(function() {
-        var $paginationSetting = helper.padChrome$('#options-pagination');
-        expect($paginationSetting.prop('checked')).to.be(false);
-        done();
-      });
-
-      this.timeout(60000);
     });
   });
 });

--- a/static/tests/frontend/specs/lineNumberHeight.js
+++ b/static/tests/frontend/specs/lineNumberHeight.js
@@ -1,3 +1,4 @@
+// TODO line numbers are not visible anymore, should we still have those tests?
 // FIXME Line numbers are not aligned to correspondent text line
 // https://trello.com/c/hdZGr9EA/684
 describe.skip('ep_script_page_view - height of line numbers', function() {

--- a/static/tests/frontend/specs/repaginate.js
+++ b/static/tests/frontend/specs/repaginate.js
@@ -1,16 +1,15 @@
-describe.skip('ep_script_page_view - repaginate', function() {
-  var utils, smUtils;
+describe('ep_script_page_view - repaginate', function() {
+  var utils = ep_script_page_view_test_helper.utils;
+  var smUtils;
 
-  before(function(){
-    utils = ep_script_page_view_test_helper.utils;
+  before(function(done) {
     smUtils = ep_script_scene_marks_test_helper.utils;
+    helper.newPad(done);
+    this.timeout(60000);
   });
 
-  beforeEach(function(done){
-    helper.newPad(function() {
-      utils.cleanPad(done);
-    });
-    this.timeout(60000);
+  beforeEach(function(done) {
+    utils.cleanPad(done);
   });
 
   context('when user inserts text on a line', function() {
@@ -23,10 +22,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
       var script = utils.buildScriptWithGenerals(lastLineText, GENERALS_PER_PAGE + 1);
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -41,11 +37,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
       $lineBeforePageBreak.sendkeys('. ' + fullLine);
 
       // wait for pagination to be re-run
-      helper.waitFor(function() {
-        // now we have a split page break instead of a non-split one
-        var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-        return $linesWithPageBreaks.length > 0;
-      }, 2000).done(function() {
+      utils.waitToHaveAnySplitPageBreak(function() {
         var $firstLineOfSecondPage = utils.linesAfterSplitPageBreaks().first();
 
         expect(utils.cleanText($firstLineOfSecondPage.text())).to.be(fullLine);
@@ -55,6 +47,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     });
   });
 
+  // FIXME
   context('when user removes text from a line', function() {
     var firstHalfOfSplit, secondHalfOfSplit;
 
@@ -77,10 +70,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnySplitPageBreak(done);
       });
     });
 
@@ -93,12 +83,9 @@ describe.skip('ep_script_page_view - repaginate', function() {
       var $textToBeRemoved = inner$('div b');
       $textToBeRemoved.sendkeys('{selectall}{backspace}');
 
-      // wait for pagination to be re-run
-      helper.waitFor(function() {
-        // now we have a non-split page break instead of a split one
-        var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-        return $linesWithPageBreaks.length > 0;
-      }, 2000).done(function() {
+      // wait for pagination to be re-run. Now we have a non-split page break
+      // instead of a split one
+      utils.waitToHaveAnyNonSplitPageBreak(function() {
         var $lineBeforePageBreak = utils.linesAfterNonSplitPageBreaks().first().prev();
         var expectedLineBeforePageBreak = firstHalfOfSplit + secondHalfOfSplit;
 
@@ -109,6 +96,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     });
   });
 
+  // FIXME
   context('when user removes a full line', function() {
     var textToBeOnTopOfSecondPage;
     before(function() {
@@ -132,10 +120,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
       var script = lineToBeRemoved + pageFullOfGenerals + lineToBeAtBottomOfFirstPage + lastGeneral;
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -152,12 +137,9 @@ describe.skip('ep_script_page_view - repaginate', function() {
       // the <div> itself
       $firstLine.get(0).outerHTML = '';
 
-      // wait for pagination to be re-run
-      helper.waitFor(function() {
-        // now we have a split page break instead of a non-split one
-        var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-        return $linesWithPageBreaks.length > 0;
-      }, 2000).done(function() {
+      // wait for pagination to be re-run. Now we have a split page break
+      // instead of a non-split one
+      utils.waitToHaveAnyNonSplitPageBreak(function() {
         var $firstLineOfSecondPage = utils.linesAfterSplitPageBreaks().first();
 
         expect($firstLineOfSecondPage.text()).to.be(textToBeOnTopOfSecondPage);
@@ -171,7 +153,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     var buildLineToBeChanged, numberOfGeneralsBeforeHeading;
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       var lastLineText = 'last general';
 
@@ -195,10 +177,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
                  + lastGeneral;
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -273,7 +252,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
       });
 
       beforeEach(function(done) {
-        this.timeout(4000);
+        this.timeout(10000);
 
         var inner$ = helper.padInner$;
 
@@ -289,17 +268,14 @@ describe.skip('ep_script_page_view - repaginate', function() {
         $lastLine.html(anotherPage);
 
         // wait for pagination to finish
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 1;
-        }, 3000).done(function() {
+        utils.waitToHaveNNonSplitPageBreaks(2, function() {
           // store ids of lines with page break to verify later if they had changed
           var $linesWithPageBreaks           = inner$('div:has(nonsplitpagebreak)');
           originalIdOfFirstLineWithPageBreak = $linesWithPageBreaks.first().attr('id');
           originalIdOfLastLineWithPageBreak  = $linesWithPageBreaks.last().attr('id');
 
           // change line on bottom of block (heading => character => dialogue) to destroy the block
-          smUtils.changeLineToElement(utils.GENERAL, changedLine, function() {
+          smUtils.changeLineToElement(utils.ACTION, changedLine, function() {
             // wait for pagination to be re-run before start testing
             helper.waitFor(function() {
               // id of line with last page break should be different
@@ -308,7 +284,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
               var newIdOfLastLineWithPageBreak = $lineWithLastPageBreak.attr('id');
 
               return ($linesAfterPageBreaks.length === 2) && (newIdOfLastLineWithPageBreak !== originalIdOfLastLineWithPageBreak);
-            }, 2000).done(done);
+            }, 5000).done(done);
           });
         });
       });
@@ -361,7 +337,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     }
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(20000);
 
       var lastLineText = 'last line';
 
@@ -373,10 +349,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(function() {
+        utils.waitToHaveAnyNonSplitPageBreak(function() {
           // store value for tests
           originalIdOfLineWithLastPageBreak = getIdOfLineWithLastPageBreak();
 
@@ -421,7 +394,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
   context('when line after a page break has top margin', function() {
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       var lastLineText = 'general';
 
@@ -439,10 +412,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length === 2;
-        }, 2000).done(done);
+        utils.waitToHaveNNonSplitPageBreaks(2, done);
       });
     });
 
@@ -457,10 +427,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
       $lineAfterHeading.get(0).outerHTML = '';
 
       // wait for repagination to finish
-      helper.waitFor(function() {
-        var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-        return $linesWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNNonSplitPageBreaks(1, function() {
         // although there are 2 empty lines on 1st page, the heading itself needs 3 lines
         // (1 for text and 2 for top margin), so it should still be on top of 2nd page
         var $firstLineOfSecondPage = utils.linesAfterNonSplitPageBreaks().first();
@@ -476,7 +443,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     var lines;
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       var lastLineText = 'general';
 
@@ -492,10 +459,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
       var script = fullPage + lastGeneral;
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -506,15 +470,12 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       // insert text on first line to change page break from non-split to split
       var longText = utils.buildStringWithLength(62, '1');
-      var $firstLine = inner$('div').first();
+      var $firstLine = inner$('div span').first();
       $firstLine.sendkeys(longText);
 
-      // wait for pagination to be re-run
-      helper.waitFor(function() {
-        // now we have a split page break instead of a non-split one
-        var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-        return $linesWithPageBreaks.length > 0;
-      }, 2000).done(function() {
+      // wait for pagination to be re-run. Now we have a split page break
+      // instead of a non-split one
+      utils.waitToHaveAnySplitPageBreak(function() {
         var $firstLineOfSecondPage = utils.linesAfterSplitPageBreaks().first();
         var secondHalfOfSplit = lines[1];
 
@@ -559,7 +520,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     }
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       var lastLineText = 'general';
 
@@ -573,10 +534,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNNonSplitPageBreaks(1, function() {
           // show/hide once first, then show again (to force char to move from
           // act to heading to act again)
           clickToShowSceneMarks(function() {
@@ -617,7 +575,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     var TEXT_OF_LAST_LINE = 'first line of 3rd page';
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       // build script with 1st page almost full of generals + one heading with act and seq on
       // bottom of 1st page (to be moved to 2nd page) + a page almost full of generals +
@@ -636,10 +594,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, TEXT_OF_LAST_LINE, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -650,13 +605,12 @@ describe.skip('ep_script_page_view - repaginate', function() {
       // to next page and last line to the 3rd page
       var oneLineLong = utils.buildStringWithLength(61, '.');
       var $lineOn1stPage = utils.getLine(GENERALS_PER_PAGE/2);
-      $lineOn1stPage.sendkeys(oneLineLong);
+      // need to change the span, not the div. Otherwise we would not correctly
+      // simulate what happens when user types something on the pad
+      $lineOn1stPage.find('span').first().sendkeys(oneLineLong);
 
       // wait for repagination to finish
-      helper.waitFor(function() {
-        var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-        return $linesWithPageBreaks.length === 2;
-      }, 2000).done(function() {
+      utils.waitToHaveNNonSplitPageBreaks(2, function() {
         var $topOfPages = utils.linesAfterNonSplitPageBreaks();
         var $topOf2ndPage = $topOfPages.first();
         var $topOfLastPage = $topOfPages.last();
@@ -673,7 +627,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     var TEXT_OF_LAST_LINE = 'first line of 3rd page';
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       // build script with 1st page almost full of generals + one heading with act and seq on
       // bottom of 1st page (to be moved to 2nd page) + a page almost full of generals +
@@ -692,10 +646,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, TEXT_OF_LAST_LINE, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -706,13 +657,12 @@ describe.skip('ep_script_page_view - repaginate', function() {
       // to next page and last line to the 3rd page
       var oneLineLong = utils.buildStringWithLength(61, '.');
       var $lineOn1stPage = utils.getLine(GENERALS_PER_PAGE/2);
-      $lineOn1stPage.sendkeys(oneLineLong);
+      // need to change the span, not the div. Otherwise we would not correctly
+      // simulate what happens when user types something on the pad
+      $lineOn1stPage.find('span').first().sendkeys(oneLineLong);
 
       // wait for repagination to finish
-      helper.waitFor(function() {
-        var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-        return $linesWithPageBreaks.length === 2;
-      }, 2000).done(function() {
+      utils.waitToHaveNNonSplitPageBreaks(2, function() {
         var $topOfPages = utils.linesAfterNonSplitPageBreaks();
         var $topOf2ndPage = $topOfPages.first();
         var $topOfLastPage = $topOfPages.last();
@@ -729,7 +679,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
     var TEXT_OF_FUTURE_TOP_OF_PAGE = 'this is going to be a heading';
 
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       // build script with 1st page full of generals + one heading with act and seq on
       // top of 2nd page + some generals
@@ -744,10 +694,7 @@ describe.skip('ep_script_page_view - repaginate', function() {
 
       utils.createScriptWith(script, 'general', function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length > 0;
-        }, 2000).done(done);
+        utils.waitToHaveAnyNonSplitPageBreak(done);
       });
     });
 
@@ -772,31 +719,6 @@ describe.skip('ep_script_page_view - repaginate', function() {
           var $firstScriptElementOfSecondPage = utils.getFirstScriptElementOfPageStartingAt($firstLineOfSecondPage);
           return $firstScriptElementOfSecondPage.text() === TEXT_OF_FUTURE_TOP_OF_PAGE;
         }, 2000).done(done);
-      });
-    });
-
-    context('and user edits a line on first page without changing its height', function() {
-      beforeEach(function(done) {
-        var originalIdOfLineWithPageBreak = utils.linesAfterNonSplitPageBreaks().first().prev().attr('id');
-
-        // edit a line on first page
-        var $lineOn1stPage = utils.getLine(GENERALS_PER_PAGE/2);
-        $lineOn1stPage.sendkeys(' [edited] ');
-
-        // wait for repagination to finish
-        helper.waitFor(function() {
-          var newIdOfLineWithPageBreak = utils.linesAfterNonSplitPageBreaks().first().prev().attr('id');
-          return originalIdOfLineWithPageBreak !== newIdOfLineWithPageBreak;
-        }, 2000).done(done);
-      });
-
-      it('recalculates page breaks taking into account the future margin heading would have if it was moved to bottom of previous page (i.e.: "keeps heading on top of page")', function(done) {
-        this.timeout(4000);
-
-        var $topOf2ndPage = utils.linesAfterNonSplitPageBreaks().first();
-        expect($topOf2ndPage.text()).to.be('first act');
-
-        done();
       });
     });
   });

--- a/static/tests/frontend/specs/scroll.js
+++ b/static/tests/frontend/specs/scroll.js
@@ -1,20 +1,18 @@
-describe.skip('ep_script_page_view - scroll', function() {
-  var utils;
+describe('ep_script_page_view - scroll', function() {
+  var utils = ep_script_page_view_test_helper.utils;
 
-  before(function(){
-    utils = ep_script_page_view_test_helper.utils;
+  before(function(done) {
+    helper.newPad(done);
+    this.timeout(60000);
   });
 
-  beforeEach(function(done){
-    helper.newPad(function() {
-      utils.cleanPad(done);
-    });
-    this.timeout(60000);
+  beforeEach(function(done) {
+    utils.cleanPad(done);
   });
 
   context('when user edits a line with page break', function() {
     beforeEach(function(done) {
-      this.timeout(4000);
+      this.timeout(10000);
 
       var lastLineText = 'general';
 
@@ -22,10 +20,7 @@ describe.skip('ep_script_page_view - scroll', function() {
       var script = utils.buildScriptWithGenerals(lastLineText, 3*GENERALS_PER_PAGE);
       utils.createScriptWith(script, lastLineText, function() {
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length === 2;
-        }, 2000).done(done);
+        utils.waitToHaveNNonSplitPageBreaks(2, done);
       });
     });
 
@@ -49,17 +44,14 @@ describe.skip('ep_script_page_view - scroll', function() {
       var lastLineOfSecondPage = 2*GENERALS_PER_PAGE-1;
 
       beforeEach(function (done) {
-        this.timeout(3000);
+        this.timeout(10000);
 
         // make line a split line, but leave room for some more text at the end of 1st half
         var longText = utils.buildStringWithLength(57, '1') + ' ';
         utils.getLine(lastLineOfSecondPage).sendkeys(longText);
 
         // wait for pagination to finish before start testing
-        helper.waitFor(function() {
-          var $linesWithSplitPageBreaks = utils.linesAfterSplitPageBreaks();
-          return $linesWithSplitPageBreaks.length === 1;
-        }, 2000).done(done);
+        utils.waitToHaveNSplitPageBreaks(1, done);
       });
 
       it('keeps line with caret on same position of viewport when edit 1st half of split', function(done) {
@@ -174,10 +166,7 @@ describe.skip('ep_script_page_view - scroll', function() {
       var script = utils.buildStringWithLength(NUMBER_OF_PAGES, fullPage) + lastLine;
       utils.createScriptWith(script, lastLineText, function() {
         // wait for initial pagination to finish
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-          return $linesWithPageBreaks.length === NUMBER_OF_PAGES;
-        }, 10000).done(function() {
+        utils.waitToHaveNNonSplitPageBreaks(NUMBER_OF_PAGES, function() {
           // change target line text, to be easier to visualize what should be on top of viewport
           var $targetLine = utils.getLine(targetLineNumber);
           $targetLine.sendkeys('{selectall}{backspace}');
@@ -198,10 +187,7 @@ describe.skip('ep_script_page_view - scroll', function() {
 
           // wait for first cycle of repagination to be completed before moving caret and viewport
           // to target lines (otherwise Etherpad will overwrite this viewport moving)
-          helper.waitFor(function() {
-            var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-            return $linesWithPageBreaks.length > 1;
-          }, 2000).done(function() {
+          utils.waitToHaveAnySplitPageBreak(function() {
             moveCaretToLineAfterFirstPaginationCycle(function() {
               utils.moveViewportToLine(targetLineNumberAfter1stCycleWithSplitPageBreaks());
 
@@ -227,10 +213,7 @@ describe.skip('ep_script_page_view - scroll', function() {
         this.timeout(14000);
 
         // check if viewport is still where it should be after repagination is complete
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-          return $linesWithPageBreaks.length === NUMBER_OF_PAGES;
-        }, 10000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(NUMBER_OF_PAGES, function() {
           utils.testLineIsOnTopOfViewport(targetLineNumberAfterFullRepaginationWithSplitPageBreaks(), done);
         });
       });
@@ -247,10 +230,7 @@ describe.skip('ep_script_page_view - scroll', function() {
         this.timeout(10000);
 
         // wait for repagination to complete
-        helper.waitFor(function() {
-          var $linesWithPageBreaks = utils.linesAfterSplitPageBreaks();
-          return $linesWithPageBreaks.length === NUMBER_OF_PAGES;
-        }, 10000).done(done);
+        utils.waitToHaveNSplitPageBreaks(NUMBER_OF_PAGES, done);
       });
 
       it('keeps first visible line always on top of viewport', function(done) {
@@ -269,16 +249,9 @@ describe.skip('ep_script_page_view - scroll', function() {
 
           // wait for first cycle of repagination to be completed before moving viewport
           // to target line (otherwise Etherpad will overrite this viewport moving)
-          helper.waitFor(function() {
-            var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-            return $linesWithPageBreaks.length > 1;
-          }, 2000).done(function() {
+          utils.waitToHaveAnyNonSplitPageBreak(function() {
             utils.moveViewportToLine(lineNumberAfterFirstCycle);
-
-            helper.waitFor(function() {
-              var $linesWithPageBreaks = utils.linesAfterNonSplitPageBreaks();
-              return $linesWithPageBreaks.length === NUMBER_OF_PAGES;
-            }, 10000).done(done);
+            utils.waitToHaveNNonSplitPageBreaks(NUMBER_OF_PAGES, done);
           });
         });
 

--- a/static/tests/frontend/specs/splitElements.js
+++ b/static/tests/frontend/specs/splitElements.js
@@ -1,26 +1,26 @@
-describe.skip('ep_script_page_view - pagination of split elements', function() {
+describe('ep_script_page_view - pagination of split elements', function() {
   // shortcuts for helper functions
   var utils, splitElements;
   // context-dependent values/functions
   var linesBeforeTargetElement, buildTargetElement, targetElementText, sentences;
 
-  before(function(){
+  before(function(done) {
     utils = ep_script_page_view_test_helper.utils;
     splitElements = ep_script_page_view_test_helper.splitElements;
+    helper.newPad(done);
+    this.timeout(60000);
   });
 
-  beforeEach(function(cb){
-    helper.newPad(function() {
-      utils.cleanPad(function() {
-        var generals      = utils.buildScriptWithGenerals('general', linesBeforeTargetElement);
-        var targetElement = buildTargetElement();
-        var lastGeneral   = utils.general('last general')
-        var script        = generals + targetElement + lastGeneral;
+  beforeEach(function(done) {
+    this.timeout(5000);
+    utils.cleanPad(function() {
+      var generals      = utils.buildScriptWithGenerals('general', linesBeforeTargetElement);
+      var targetElement = buildTargetElement();
+      var lastGeneral   = utils.general('last general')
+      var script        = generals + targetElement + lastGeneral;
 
-        utils.createScriptWith(script, 'last general', cb);
-      });
+      utils.createScriptWith(script, 'last general', done);
     });
-    this.timeout(60000);
   });
 
   context('when first line of page is a very long general', function() {
@@ -39,13 +39,11 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
     });
 
     it('splits the original line into two separated lines', function(done) {
+      this.timeout(5000);
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
-      helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-        return $splitElementsWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNSplitPageBreaks(1, function() {
         var $lines = inner$('div');
         var $targetLine = $lines.last().prev();
         var textOnLastDiv = sentences[1] + sentences[2] + sentences[3];
@@ -63,10 +61,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
-      helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-        return $splitElementsWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNSplitPageBreaks(1, function() {
         // create another very long general before the last one, so pagination needs to be re-done
         // (The extra '.prev()' is because we insert a '\n' when line is split between pages)
         var $threeLinesGeneral = inner$('div').last().prev().prev().prev();
@@ -98,10 +93,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
-      helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-        return $splitElementsWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNSplitPageBreaks(1, function() {
         // create another very long general before the last one, so pagination needs to be re-done
         // (The extra '.prev()' is because we insert a '\n' when line is split between pages)
         var $threeLinesGeneral = inner$('div').last().prev().prev().prev();
@@ -134,10 +126,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
-      helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-        return $splitElementsWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNSplitPageBreaks(1, function() {
         // write something on fist half of split line
         var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
         $firstHalfOfSplitLine.sendkeys('{selectall}{rightarrow}');
@@ -166,10 +155,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
-      helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-        return $splitElementsWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNSplitPageBreaks(1, function() {
         // write something on second half of split line
         var $secondHalfOfSplitLine = inner$('div:has(splitPageBreak)').first().next();
         // sendkeys fails if we apply it to <div>. Need to apply to the inner span
@@ -199,10 +185,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       var inner$ = helper.padInner$;
 
       // there should be a page break before we start testing
-      helper.waitFor(function() {
-        var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-        return $splitElementsWithPageBreaks.length === 1;
-      }, 2000).done(function() {
+      utils.waitToHaveNSplitPageBreaks(1, function() {
         // 'copy' content of split line
         var $firstHalfOfSplitLine = inner$('div:has(splitPageBreak)').first();
         var $secondHalfOfSplitLine = $firstHalfOfSplitLine.next();
@@ -277,10 +260,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(1, function() {
           // edit one element
           var $elementToBeEdited = inner$('div').last().prev().prev();
           var originalText = $elementToBeEdited.text();
@@ -340,15 +320,12 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
 
       it('considers the height of the resulting second half of the element split', function(done) {
-        this.timeout(5000);
+        this.timeout(10000);
 
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div nonSplitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNNonSplitPageBreaks(1, function() {
           // change 57th line to be 3-lines-long (2 sentences, each ~1.25 long, so when they are
           // split they need 2 lines each)
           // build sentences that are ~1.25 line long (when split they need 2 lines each)
@@ -360,10 +337,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           $lineAtEndOfFirstPage.sendkeys(sentence1 + sentence2);
 
           // wait for edition to be processed and pagination to be complete
-          helper.waitFor(function() {
-            var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-            return $splitElementsWithPageBreaks.length > 0;
-          }, 3000).done(function() {
+          utils.waitToHaveAnySplitPageBreak(function() {
             // 1: verify first page break was added between the two sentences of 57th line
             utils.testSplitPageBreakIsOn(sentence2, function() {
               // 2: verify second page break was added on top of last line
@@ -445,10 +419,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(1, function() {
           // repeat some times: remove one line then check is pagination is correct
           var textBeforePageBreak = sentences[0] + sentences[1];
           splitElements.removeFirstLineAndExpectTextBeforePageBreakToBe(textBeforePageBreak, function() {
@@ -493,10 +464,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         $targetLine.sendkeys('{selectall}').sendkeys('not ' + multiLineText + veryLongLine);
 
         // wait for pagination to finish
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(1, function() {
           // Select part of 1st and 2nd halves of same split to be able to remove them at the same time.
           var $firstHalfOfSplitLine  = inner$('div:has(splitPageBreak)');
           var $secondHalfOfSplitLine = $firstHalfOfSplitLine.next();
@@ -508,10 +476,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           utils.pressBackspace();
 
           // wait for pagination to finish (content is removed, lines merged, etc.)
-          helper.waitFor(function() {
-            var $nonSplitElementsWithPageBreaks = inner$('div nonSplitPageBreak');
-            return $nonSplitElementsWithPageBreaks.length === 1;
-          }, 2000).done(function() {
+          utils.waitToHaveNNonSplitPageBreaks(1, function() {
             var $lines = inner$('div');
             var $targetLine = $lines.last().prev();
             var $lineBeforeTarget = $targetLine.prev();
@@ -526,6 +491,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
     });
 
+    // FIXME
     context('and caret is at the end of 1st half of split line, and user presses DELETE', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
@@ -545,10 +511,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(1, function() {
           utils.placeCaretAtTheEndOfLine(GENERALS_PER_PAGE-1, done);
         });
       });
@@ -578,6 +541,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
     });
 
+    // FIXME
     context('and caret is at the beginning of 2nd half of split line, and user presses BACKSPACE', function() {
       before(function() {
         linesBeforeTargetElement = GENERALS_PER_PAGE - 1;
@@ -651,7 +615,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
 
       beforeEach(function(done) {
-        this.timeout(6000);
+        this.timeout(20000);
 
         var inner$ = helper.padInner$;
 
@@ -660,10 +624,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         var veryLongLine = line1 + line2;
 
         // there should be a page break before we start creating other split page breaks
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(1, function() {
           // create some other split page breaks before the existing one
           var $lastLineOfSecondPage = utils.getLine(2*GENERALS_PER_PAGE-2);
           $lastLineOfSecondPage.sendkeys('{selectall}');
@@ -674,10 +635,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           $lastLineOfFirstPage.sendkeys(veryLongLine);
 
           // there should be 3 page breaks now
-          helper.waitFor(function() {
-            var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-            return $splitElementsWithPageBreaks.length === 3;
-          }, 2000).done(done);
+          utils.waitToHaveNSplitPageBreaks(3, done);
         });
       });
 
@@ -699,7 +657,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var firstLine = function() { return helper.padInner$('div').first() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(firstLine, textAfterInsertedText, false, done);
+          splitElements.testCaretIsOn(firstLine, textAfterInsertedText, done);
         });
       });
 
@@ -725,7 +683,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var targetLine = function() { return helper.padInner$('div').last().prev() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(targetLine, textAfterInsertedText, true, done);
+          splitElements.testCaretIsOn(targetLine, textAfterInsertedText, done);
         });
       });
 
@@ -754,7 +712,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
+          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, done);
         });
       });
 
@@ -772,6 +730,9 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           done();
         });
 
+        // This context is working, but test is failing for some weird (unknown)
+        // reasons: utils.getColumnWhereCaretIs() is returning 1 even when we
+        // see on the browser that the caret is not on the column 1.
         context('and text inserted is short', function() {
           var textBeforePageBreak;
 
@@ -798,7 +759,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
             var firstHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last() };
             var textAfterInsertedText = textBeforePageBreak.length;
 
-            splitElements.testCaretIsOn(firstHalfOfSplitLine, textAfterInsertedText, false, done);
+            splitElements.testCaretIsOn(firstHalfOfSplitLine, textAfterInsertedText, done);
           });
         });
 
@@ -825,11 +786,14 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
             var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
             var textAfterInsertedText = theText.length;
 
-            splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
+            splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, done);
           });
         });
       });
 
+      // This context is working, but test is failing for some weird (unknown)
+      // reasons: utils.getColumnWhereCaretIs() is returning 1 even when we
+      // see on the browser that the caret is not on the column 1.
       context('and user adds text to the end of 2nd half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
@@ -852,7 +816,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var lineAfterPageBreak = function() { return helper.padInner$('div:has(splitPageBreak)').last().next().next() };
           var textAfterInsertedText = lineAfterPageBreak().text().length;
 
-          splitElements.testCaretIsOn(lineAfterPageBreak, textAfterInsertedText, true, done);
+          splitElements.testCaretIsOn(lineAfterPageBreak, textAfterInsertedText, done);
         });
       });
 
@@ -882,7 +846,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
+          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, done);
         });
       });
     });
@@ -907,6 +871,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
 
       it('moves the entire action for next page', function(done) {
+        this.timeout(5000);
         var wholeElement = targetElementText;
         utils.testNonSplitPageBreakIsOnScriptElementWithText(wholeElement, done);
       });
@@ -931,10 +896,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         var inner$ = helper.padInner$;
 
         // there should be a page break before we start testing
-        helper.waitFor(function() {
-          var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-          return $splitElementsWithPageBreaks.length === 1;
-        }, 2000).done(function() {
+        utils.waitToHaveNSplitPageBreaks(1, function() {
           var $secondHalfOfAction = inner$('div').last().prev();
           var $firstHalfOfAction = $secondHalfOfAction.prev();
 
@@ -958,10 +920,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var inner$ = helper.padInner$;
 
           // there should be a page break before we start testing
-          helper.waitFor(function() {
-            var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-            return $splitElementsWithPageBreaks.length === 1;
-          }, 2000).done(function() {
+          utils.waitToHaveNSplitPageBreaks(1, function() {
             // edit last line of previous page
             var $lastLineOfFirstPage = inner$('div').last().prev().prev();
             $lastLineOfFirstPage.sendkeys('{selectall}{rightarrow}');
@@ -1091,7 +1050,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
 
       beforeEach(function(done) {
-        this.timeout(6000);
+        this.timeout(10000);
 
         var smUtils = ep_script_scene_marks_test_helper.utils;
         var inner$ = helper.padInner$;
@@ -1102,23 +1061,23 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
         var line4 = utils.buildStringWithLength(59, 'Z') + '. ';
         var veryLongLine = line1 + line2 + line3 + line4;
 
-        // create some other actions with split page breaks before the existing one
-        var $lastLineOfFirstPage = utils.getLine(LAST_LINE_OF_PAGE_1);
-        $lastLineOfFirstPage.sendkeys('{selectall}');
-        $lastLineOfFirstPage.sendkeys(veryLongLine);
+        // make sure first pagination had already run
+        utils.waitToHaveNNonSplitPageBreaks(2, function() {
+          // create some other actions with split page breaks before the existing one
+          var $lastLineOfFirstPage = utils.getLine(LAST_LINE_OF_PAGE_1);
+          $lastLineOfFirstPage.sendkeys('{selectall}');
+          $lastLineOfFirstPage.sendkeys(veryLongLine);
 
-        var $lastLineOfSecondPage = utils.getLine(LAST_LINE_OF_PAGE_2);
-        $lastLineOfSecondPage.sendkeys('{selectall}');
-        $lastLineOfSecondPage.sendkeys(veryLongLine);
+          var $lastLineOfSecondPage = utils.getLine(LAST_LINE_OF_PAGE_2);
+          $lastLineOfSecondPage.sendkeys('{selectall}');
+          $lastLineOfSecondPage.sendkeys(veryLongLine);
 
-        // change both lines to action
-        smUtils.changeLineToElement(utils.ACTION, LAST_LINE_OF_PAGE_2, function() {
-          smUtils.changeLineToElement(utils.ACTION, LAST_LINE_OF_PAGE_1, function() {
-            // there should be 3 page breaks now
-            helper.waitFor(function() {
-              var $splitElementsWithPageBreaks = inner$('div splitPageBreak');
-              return $splitElementsWithPageBreaks.length === 3;
-            }, 2000).done(done);
+          // change both lines to action
+          smUtils.changeLineToElement(utils.ACTION, LAST_LINE_OF_PAGE_2, function() {
+            smUtils.changeLineToElement(utils.ACTION, LAST_LINE_OF_PAGE_1, function() {
+              // there should be 3 page breaks now
+              utils.waitToHaveNSplitPageBreaks(3, done);
+            });
           });
         });
       });
@@ -1141,7 +1100,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var firstLine = function() { return helper.padInner$('div').first() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(firstLine, textAfterInsertedText, false, done);
+          splitElements.testCaretIsOn(firstLine, textAfterInsertedText, done);
         });
       });
 
@@ -1167,7 +1126,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var targetLine = function() { return helper.padInner$('div').last().prev() };
           var textAfterInsertedText = 'BBBBBBBBBBBB'.length;
 
-          splitElements.testCaretIsOn(targetLine, textAfterInsertedText, true, done);
+          splitElements.testCaretIsOn(targetLine, textAfterInsertedText, done);
         });
       });
 
@@ -1196,7 +1155,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
+          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, done);
         });
       });
 
@@ -1224,10 +1183,13 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
           var textAfterInsertedText = 'something'.length;
 
-          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, false, done);
+          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, done);
         });
       });
 
+      // This context is working, but test is failing for some weird (unknown)
+      // reasons: utils.getColumnWhereCaretIs() is returning 1 even when we
+      // see on the browser that the caret is not on the column 1.
       context('and user adds text to the end of 2nd half of split line', function() {
         beforeEach(function(done) {
           this.timeout(6000);
@@ -1250,7 +1212,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var lineAfterPageBreak = function() { return helper.padInner$('div:has(splitPageBreak)').last().next().next() };
           var textAfterInsertedText = lineAfterPageBreak().text().length;
 
-          splitElements.testCaretIsOn(lineAfterPageBreak, textAfterInsertedText, true, done);
+          splitElements.testCaretIsOn(lineAfterPageBreak, textAfterInsertedText, done);
         });
       });
 
@@ -1280,7 +1242,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var secondHalfOfSplitLine = function() { return helper.padInner$('div:has(splitPageBreak)').last().next() };
           var textAfterInsertedText = 'AAAAAAAAA'.length;
 
-          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, true, done);
+          splitElements.testCaretIsOn(secondHalfOfSplitLine, textAfterInsertedText, done);
         });
       });
     });
@@ -1454,7 +1416,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
       });
 
       // FIXME this is an extreme corner case, so we won't work on it for now
-      context('and inner lines do not have full length', function() {
+      context.skip('and inner lines do not have full length', function() {
         before(function() {
           linesBeforeTargetElement = 0;
 
@@ -1465,7 +1427,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           targetElementText = sentences.join('');
         });
 
-        xit('splits transition between the two pages, and second page has the last two lines of the transition', function(done) {
+        it('splits transition between the two pages, and second page has the last two lines of the transition', function(done) {
           var firstLineOnPage2 = sentences[GENERALS_PER_PAGE-1];
           utils.testSplitPageBreakIsOn(firstLineOnPage2, done);
         });
@@ -1636,10 +1598,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
             var inner$ = helper.padInner$;
 
             // wait for pagination to be finished
-            helper.waitFor(function() {
-              var $splitPageBreaks = inner$('div splitPageBreak');
-              return $splitPageBreaks.length > 0;
-            }, 2000).done(function() {
+            utils.waitToHaveAnySplitPageBreak(function() {
               // verify 2nd half is two-lines high
               var secondHalfHeight = inner$('div').last().prev().outerHeight();
               var twoLinesHigh = 2 * utils.regularLineHeight();
@@ -1676,10 +1635,7 @@ describe.skip('ep_script_page_view - pagination of split elements', function() {
           var inner$ = helper.padInner$;
 
           // wait for pagination to be finished
-          helper.waitFor(function() {
-            var $splitPageBreaks = inner$('div splitPageBreak');
-            return $splitPageBreaks.length > 0;
-          }).done(function() {
+          utils.waitToHaveAnySplitPageBreak(function() {
             // verify CONT\'D is one line high
             // (if it is not, line number and line position on editor will be different)
             var firstLineOfSecondPage = GENERALS_PER_PAGE-1;
@@ -1985,25 +1941,45 @@ ep_script_page_view_test_helper.splitElements = {
     }, 3000).done(done);
   },
 
-  testCaretIsOn: function(expectedLine, expectedColumn, withTimeout, done) {
+  _waitForCaretToBeOnLine: function(expectedLine, done) {
     var utils = ep_script_page_view_test_helper.utils;
+    helper.
+      waitFor(function() {
+        var $lineWhereCaretIs = utils.getLineWhereCaretIs();
+        return $lineWhereCaretIs.get(0) === expectedLine().get(0);
+      }).
+      done(done).
+      // give a more meaningful message
+      fail(function() {
+        var $lineWhereCaretIs = utils.getLineWhereCaretIs();
+        var message = `Expected caret to be on line ${expectedLine().index()}, but it is on ${$lineWhereCaretIs.index()}`;
+        expect().fail(message);
+      });
+  },
 
-    var theTest = function() {
-      var $lineWhereCaretIs = utils.getLineWhereCaretIs();
-      var columnWhereCaretIs = utils.getColumnWhereCaretIs();
+  _waitForCaretToBeOnColumn: function(expectedColumn, done) {
+    var utils = ep_script_page_view_test_helper.utils;
+    helper.
+      waitFor(function() {
+        var columnWhereCaretIs = utils.getColumnWhereCaretIs();
+          return columnWhereCaretIs === expectedColumn;
+      }).
+      done(done).
+      // give a more meaningful message
+      fail(function() {
+        var columnWhereCaretIs = utils.getColumnWhereCaretIs();
+        debugger
+        helper.padInner$.document.getSelection().anchorOffset
+        var message = `Expected caret to be on column ${expectedColumn}, but it is on ${columnWhereCaretIs}`;
+        expect().fail(function() { return message });
+      });
+  },
 
-      expect(columnWhereCaretIs).to.be(expectedColumn);
-      expect($lineWhereCaretIs.get(0)).to.be(expectedLine().get(0));
-
-      done();
-    };
-
-    // some tests need to to wait some time so caret finishes moving
-    if (withTimeout) {
-      setTimeout(theTest, 1000);
-    } else {
-      theTest();
-    }
+  testCaretIsOn: function(expectedLine, expectedColumn, done) {
+    var self = ep_script_page_view_test_helper.splitElements;
+    self._waitForCaretToBeOnLine(expectedLine, function() {
+      self._waitForCaretToBeOnColumn(expectedColumn, done);
+    });
   },
 
   buildLongLine: function(numberOfInnerLines, charsPerLine) {


### PR DESCRIPTION
Don't clone lines on each pagination cycle; instead, use their line sized (provided by https://github.com/storytouch/ep_script_line_size/pull/1) to calculate page breaks on the fly. This allows us to remove a lot of code related to "cloned lines", "helper lines", etc.

Also:

- optimize repagination: stop paginating when pagination cycle reaches a point where the existing page break is on the same spot of the calculated page break;
- use `Set` (instead of an object) to store lines changed on `paginationLinesChanged`
- create helper methods for tests:
  - `waitToHaveAnyPageBreak`
  - `waitToHaveAnySplitPageBreak`
  - `waitToHaveAnyNonSplitPageBreak`
  - `waitToHaveNNonSplitPageBreaks`
  - `waitToHaveNSplitPageBreaks`
- un-pend tests and fix them so they can validate pagination again:
  - [x] `basicPagination.js`: adjusted and all tests passing
  - [x] `calculatingPageNumber.js`: adjusted and all tests passing
  - [ ] `elementBlocks.js`: not adjusted
  - [x] `enablePagination.js`: adjusted and all tests passing
  - [ ] `lineNumberHeight.js` (should we remove this suite? We don't allow users to show line numbers anymore...): not adjusted
  - [ ] `otherMoreContd.js`: not adjusted
  - [ ] `repaginate.js`: adjusted, but with tests failing
  - [ ] `scroll.js`: not adjusted
  - [ ] `splitElements.js`: adjusted, but with tests failing
- optimize tests: don't create a new pad for each test, use the same one and clean pad content before starting each test. This can be even more efficient if we use UNDO instead of cleaning the pad, but to do that we need to change the tests in a lot of places, so this is not done on this commit;
- mark failing tests with `// FIXME`;

Implement part of https://trello.com/c/dJp83kE0/1971.

# Full list of PRs of this feature:

- https://github.com/storytouch/ep_webpack/pull/14
- https://github.com/storytouch/ep_script_autocomp/pull/15
- https://github.com/storytouch/ep_script_line_size/pull/1
- https://github.com/storytouch/ep_script_line_size/pull/2
- https://github.com/storytouch/ep_script_page_view/pull/17
- https://github.com/storytouch/ep_draganddrop/pull/8
- https://github.com/storytouch/ep_script_scene_marks/pull/73
- https://github.com/storytouch/ep_script_copy_cut_paste/pull/34
- https://github.com/storytouch/etherpad-docker/pull/59
