### PR TITLE
[style] adjust main position and heights in page view 

### DIFF
--- a/static/css/iframe.css
+++ b/static/css/iframe.css
@@ -8,12 +8,11 @@
 }
 
 #innerdocbody {
-  line-height: 16px;
+  line-height: 20px;
 }
 
 #innerdocbody > div {
-  padding-left: 117px;
-  padding-right: 20px;
+  padding-left: 133px;
 }
 
 /* make the comment container white as well */

--- a/static/css/pagination.css
+++ b/static/css/pagination.css
@@ -1,7 +1,7 @@
 /* Etherpad does not set #linemetricsdiv with the same line-height as the editor, and we need
    this in order to calculate page breaks when zoom is not 100% */
 #linemetricsdiv {
-  line-height: 16px;
+  line-height: 20px;
 }
 
 /* TODO review the "!important" used here. They might had been necessary when we had
@@ -51,8 +51,8 @@
 
   /* make CONT'D and character name work together */
   contdLine {
-    max-width: calc(100% - 152px - 16px + 222px);
-    min-width: calc(100% - 152px - 16px);
+    max-width: calc(100% - 152px - 20px + 222px);
+    min-width: calc(100% - 152px - 20px);
     margin-right: -222px;
   }
 
@@ -161,7 +161,7 @@
 
   /* page number: */
   div pagenumber {
-    margin-top: -32px;
+    margin-top: -40px;
     margin-right: 4px;
     float: right;
   }


### PR DESCRIPTION
This PR is related to [Trello card 2324](https://trello.com/c/LimvIHH4/2324-corrigir-estilos-quebrados-no-novo-etherpad) and it adjusts the styles of the page view plugin after we updated the Etherpad version.

Most part of the styles changes are due to the new zoom of the Etherpad iframe.

The main line height of the elements have been changed from 16px to 20px.

How it was:
<img width="574" alt="was" src="https://user-images.githubusercontent.com/31015005/90562111-1271e280-e178-11ea-9bc3-c1a3d5270204.png">


How it is:
<img width="575" alt="is" src="https://user-images.githubusercontent.com/31015005/90562118-16056980-e178-11ea-9649-7b0b507d12be.png">
