### PR TITLE
[style] Decrease space between editor left bound and script elements

### DIFF
--- a/static/css/iframe.css
+++ b/static/css/iframe.css
@@ -12,7 +12,7 @@
 }
 
 #innerdocbody > div {
-  padding-left: 133px;
+  padding-left: 118px;
 }
 
 /*


### PR DESCRIPTION
This PR is related to [Trello Card 2551](https://trello.com/c/m8TDBTLG/2551-ajustes-visuais-texto-livre).

Text body requires more space now that we've implemented Courier Prime, because this font is larger.  
So we had to decrease margins on the left side of script text so the comment icons column doesn't cut the right part of the text.

<img width="633" alt="padding" src="https://user-images.githubusercontent.com/31015005/106644359-c66dfb00-6569-11eb-946c-c07ab88a0644.png">
