### PR TITLE
[refactor] Get number of lines per page from page layout

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,6 +2,7 @@
   "parts": [
     {
       "name": "page_view",
+      "pre": ["ep_script_simple_page_view/preLoader"],
       "client_hooks": {
         "postAceInit": "ep_script_page_view/static/js/index",
         "aceEditorCSS": "ep_script_page_view/static/js/aceEditorCSS",

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -2,6 +2,7 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var Security = require('ep_etherpad-lite/static/js/security');
 
+var simplePageViewUtils = require('ep_script_simple_page_view/static/js/utils');
 var scriptElementUtils = require('ep_script_elements/static/js/utils');
 
 var EMPTY_CHARACTER_NAME = "empty";
@@ -10,11 +11,6 @@ var SCRIPT_ELEMENTS_SELECTOR = "heading, action, character, parenthetical, dialo
 
 var CLONED_ELEMENTS_CLASS = "cloned";
 var CLONED_ELEMENTS_SELECTOR = "." + CLONED_ELEMENTS_CLASS;
-
-// Letter
-// var REGULAR_LINES_PER_PAGE = 54;
-// A4
-var REGULAR_LINES_PER_PAGE = 58;
 
 // WARNING: if you change any of these values, you need to change on the CSS of page breaks too
 var DEFAULT_PAGE_BREAK_HEIGHT = 10;
@@ -305,11 +301,12 @@ var getPageBreakTagsSelector = function() {
 }
 exports.getPageBreakTagsSelector = getPageBreakTagsSelector;
 
-// Use line proportion to find height needed so we always have REGULAR_LINES_PER_PAGE generals/page
+// Use line proportion to find height needed so we always have
+// the same amount of generals per page
 var calculatePageHeight = function(oneLineHeight) {
   oneLineHeight = oneLineHeight || getHeightOfOneLine();
-  var pageHeightNeeded = oneLineHeight * REGULAR_LINES_PER_PAGE;
-
+  var numberOfLinesPerPage = simplePageViewUtils.getThisPlugin().pageLayout.getNumberOfLinesPerPage();
+  var pageHeightNeeded = oneLineHeight * numberOfLinesPerPage;
   return pageHeightNeeded;
 }
 

--- a/static/tests/frontend/specs/basicPagination.js
+++ b/static/tests/frontend/specs/basicPagination.js
@@ -1,24 +1,26 @@
-// Letter
-// var GENERALS_PER_PAGE       = 54;
-// var HEADINGS_PER_PAGE       = 18;
-// var ACTIONS_PER_PAGE        = 27;
-// var CHARACTERS_PER_PAGE     = 27;
-// var PARENTHETICALS_PER_PAGE = 54;
-// var DIALOGUES_PER_PAGE      = 54;
-// var TRANSITIONS_PER_PAGE    = 26;
-// var SHOTS_PER_PAGE          = 18;
-
-// A4
-var GENERALS_PER_PAGE       = 58;
-var HEADINGS_PER_PAGE       = 20;
-var ACTIONS_PER_PAGE        = 29;
-var CHARACTERS_PER_PAGE     = 29;
-var PARENTHETICALS_PER_PAGE = 58;
-var DIALOGUES_PER_PAGE      = 58;
-var TRANSITIONS_PER_PAGE    = 28;
-var SHOTS_PER_PAGE          = 20;
-
 describe.skip("ep_script_page_view - pagination basic tests", function() {
+  // Letter
+  // var PAPER                   = 'Letter';
+  // var GENERALS_PER_PAGE       = 54;
+  // var HEADINGS_PER_PAGE       = 18;
+  // var ACTIONS_PER_PAGE        = 27;
+  // var CHARACTERS_PER_PAGE     = 27;
+  // var PARENTHETICALS_PER_PAGE = 54;
+  // var DIALOGUES_PER_PAGE      = 54;
+  // var TRANSITIONS_PER_PAGE    = 26;
+  // var SHOTS_PER_PAGE          = 18;
+
+  // A4
+  var PAPER                   = 'A4';
+  var GENERALS_PER_PAGE       = 58;
+  var HEADINGS_PER_PAGE       = 20;
+  var ACTIONS_PER_PAGE        = 29;
+  var CHARACTERS_PER_PAGE     = 29;
+  var PARENTHETICALS_PER_PAGE = 58;
+  var DIALOGUES_PER_PAGE      = 58;
+  var TRANSITIONS_PER_PAGE    = 28;
+  var SHOTS_PER_PAGE          = 20;
+
   var utils, pageBreak;
 
   var getPageBuilder = function(elementsPerPage, builder) {
@@ -29,7 +31,10 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
   before(function(done) {
     utils = ep_script_page_view_test_helper.utils;
     pageBreak = ep_script_page_view_test_helper.pageBreak;
-    helper.newPad(done);
+
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(done, PAPER);
+
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/calculatingPageNumber.js
+++ b/static/tests/frontend/specs/calculatingPageNumber.js
@@ -1,4 +1,11 @@
 describe.skip("ep_script_page_view - calculating page number", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var utils;
 
   before(function(){
@@ -6,9 +13,10 @@ describe.skip("ep_script_page_view - calculating page number", function() {
   });
 
   beforeEach(function(done){
-    helper.newPad(function() {
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(done);
-    });
+    }, PAPER);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/elementBlocks.js
+++ b/static/tests/frontend/specs/elementBlocks.js
@@ -1,9 +1,11 @@
-// Letter
-// var GENERALS_PER_PAGE = 54;
-// A4
-var GENERALS_PER_PAGE = 58;
-
 describe.skip("ep_script_page_view - pagination of element blocks", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var utils;
 
   var undoLastChanges = function(done) {
@@ -113,7 +115,8 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
   before(function(done) {
     utils = ep_script_page_view_test_helper.utils;
 
-    helper.newPad(done);
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(done, PAPER);
 
     this.timeout(60000);
   });

--- a/static/tests/frontend/specs/enablePagination.js
+++ b/static/tests/frontend/specs/enablePagination.js
@@ -1,9 +1,16 @@
 describe.skip('ep_script_page_view - Enable / Disable automatic pagination', function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var NUMBER_OF_PAGES = 3;
   var SHOULD_HAVE_PAGE_BREAK = true;
   var SHOULD_NOT_HAVE_PAGE_BREAK = false;
 
-  var utils, padId;
+  var utils, padId, simplePageViewUtils;
 
   var waitForPageBreaksChange = function(shouldHavePageBreak, done) {
     helper.waitFor(function() {
@@ -20,14 +27,15 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
 
   before(function(done) {
     utils = ep_script_page_view_test_helper.utils;
+    simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
 
-    padId = helper.newPad(function() {
+    padId = simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(function() {
         // build a script with 3 full pages an an extra line on 4th page
         var script = utils.buildScriptWithGenerals('general', NUMBER_OF_PAGES * GENERALS_PER_PAGE + 1);
         utils.createScriptWith(script, 'general', done);
       });
-    });
+    }, PAPER);
 
     this.timeout(60000);
   });
@@ -76,12 +84,12 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
         setTimeout(function() {
           // load another pad, so can disable pagination without affecting page breaks of
           // original pad
-          helper.newPad(function() {
+          simplePageViewUtils.newPadWithPaperType(function() {
             utils.disablePagination();
 
             // load original pad, the one with page breaks
             helper.newPad(done, padId);
-          });
+          }, PAPER);
         }, 1000);
       });
 
@@ -111,11 +119,11 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
 
     it('loads new pads with pagination disabled', function(done) {
       // load a new pad
-      helper.newPad(function() {
+      simplePageViewUtils.newPadWithPaperType(function() {
         var $paginationSetting = helper.padChrome$('#options-pagination');
         expect($paginationSetting.prop('checked')).to.be(false);
         done();
-      });
+      }, PAPER);
 
       this.timeout(60000);
     });

--- a/static/tests/frontend/specs/lineNumberHeight.js
+++ b/static/tests/frontend/specs/lineNumberHeight.js
@@ -1,6 +1,13 @@
 // FIXME Line numbers are not aligned to correspondent text line
 // https://trello.com/c/hdZGr9EA/684
 describe.skip("ep_script_page_view - height of line numbers", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var utils;
 
   before(function(){
@@ -8,9 +15,10 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
   });
 
   beforeEach(function(done){
-    helper.newPad(function() {
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(done);
-    });
+    }, PAPER);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/otherMoreContd.js
+++ b/static/tests/frontend/specs/otherMoreContd.js
@@ -1,4 +1,11 @@
 describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var utils, scriptBuilder, lastLineText;
 
   before(function(){
@@ -6,11 +13,12 @@ describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
   });
 
   beforeEach(function(cb){
-    helper.newPad(function() {
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(function() {
         utils.createScriptWith(scriptBuilder(), lastLineText, cb);
       });
-    });
+    }, PAPER);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/repaginate.js
+++ b/static/tests/frontend/specs/repaginate.js
@@ -1,4 +1,11 @@
 describe.skip("ep_script_page_view - repaginate", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var utils, smUtils;
 
   before(function(){
@@ -7,9 +14,10 @@ describe.skip("ep_script_page_view - repaginate", function() {
   });
 
   beforeEach(function(done){
-    helper.newPad(function() {
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(done);
-    });
+    }, PAPER);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/scroll.js
+++ b/static/tests/frontend/specs/scroll.js
@@ -1,4 +1,11 @@
 describe.skip("ep_script_page_view - scroll", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   var utils;
 
   before(function(){
@@ -6,9 +13,10 @@ describe.skip("ep_script_page_view - scroll", function() {
   });
 
   beforeEach(function(done){
-    helper.newPad(function() {
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(done);
-    });
+    }, PAPER);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/splitElements.js
+++ b/static/tests/frontend/specs/splitElements.js
@@ -1,4 +1,11 @@
 describe.skip("ep_script_page_view - pagination of split elements", function() {
+  // Letter
+  // var PAPER = 'Letter';
+  // var GENERALS_PER_PAGE = 54;
+  // A4
+  var PAPER = 'A4';
+  var GENERALS_PER_PAGE = 58;
+
   // shortcuts for helper functions
   var utils, splitElements;
   // context-dependent values/functions
@@ -10,7 +17,8 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
   });
 
   beforeEach(function(cb){
-    helper.newPad(function() {
+    var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
+    simplePageViewUtils.newPadWithPaperType(function() {
       utils.cleanPad(function() {
         var generals      = utils.buildScriptWithGenerals("general", linesBeforeTargetElement);
         var targetElement = buildTargetElement();
@@ -19,7 +27,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         utils.createScriptWith(script, "last general", cb);
       });
-    });
+    }, PAPER);
     this.timeout(60000);
   });
 


### PR DESCRIPTION
As we are now supporting Letter paper, we updated this plugin to get the right number of lines per page available on the current paper defined in the pad.

Depends on: https://github.com/storytouch/ep_script_simple_page_view/pull/22
It's related to [card 3038](https://trello.com/c/QTRYv7zw).