### PR TITLE
[refactor] Renames paperType to paperSize

### DIFF
--- a/static/tests/frontend/specs/basicPagination.js
+++ b/static/tests/frontend/specs/basicPagination.js
@@ -1,6 +1,6 @@
 describe.skip("ep_script_page_view - pagination basic tests", function() {
   // Letter
-  // var PAPER                   = 'Letter';
+  // var PAPER_SZE               = 'Letter';
   // var GENERALS_PER_PAGE       = 54;
   // var HEADINGS_PER_PAGE       = 18;
   // var ACTIONS_PER_PAGE        = 27;
@@ -11,7 +11,7 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
   // var SHOTS_PER_PAGE          = 18;
 
   // A4
-  var PAPER                   = 'A4';
+  var PAPER_SZE               = 'A4';
   var GENERALS_PER_PAGE       = 58;
   var HEADINGS_PER_PAGE       = 20;
   var ACTIONS_PER_PAGE        = 29;
@@ -33,7 +33,7 @@ describe.skip("ep_script_page_view - pagination basic tests", function() {
     pageBreak = ep_script_page_view_test_helper.pageBreak;
 
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(done, PAPER);
+    simplePageViewUtils.newPadWithPaperSize(done, PAPER_SZE);
 
     this.timeout(60000);
   });

--- a/static/tests/frontend/specs/calculatingPageNumber.js
+++ b/static/tests/frontend/specs/calculatingPageNumber.js
@@ -1,9 +1,9 @@
 describe.skip("ep_script_page_view - calculating page number", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var utils;
@@ -14,9 +14,9 @@ describe.skip("ep_script_page_view - calculating page number", function() {
 
   beforeEach(function(done){
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(function() {
+    simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(done);
-    }, PAPER);
+    }, PAPER_SZE);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/elementBlocks.js
+++ b/static/tests/frontend/specs/elementBlocks.js
@@ -1,9 +1,9 @@
 describe.skip("ep_script_page_view - pagination of element blocks", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var utils;
@@ -116,7 +116,7 @@ describe.skip("ep_script_page_view - pagination of element blocks", function() {
     utils = ep_script_page_view_test_helper.utils;
 
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(done, PAPER);
+    simplePageViewUtils.newPadWithPaperSize(done, PAPER_SZE);
 
     this.timeout(60000);
   });

--- a/static/tests/frontend/specs/enablePagination.js
+++ b/static/tests/frontend/specs/enablePagination.js
@@ -1,9 +1,9 @@
 describe.skip('ep_script_page_view - Enable / Disable automatic pagination', function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var NUMBER_OF_PAGES = 3;
@@ -29,13 +29,13 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
     utils = ep_script_page_view_test_helper.utils;
     simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
 
-    padId = simplePageViewUtils.newPadWithPaperType(function() {
+    padId = simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(function() {
         // build a script with 3 full pages an an extra line on 4th page
         var script = utils.buildScriptWithGenerals('general', NUMBER_OF_PAGES * GENERALS_PER_PAGE + 1);
         utils.createScriptWith(script, 'general', done);
       });
-    }, PAPER);
+    }, PAPER_SZE);
 
     this.timeout(60000);
   });
@@ -84,12 +84,12 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
         setTimeout(function() {
           // load another pad, so can disable pagination without affecting page breaks of
           // original pad
-          simplePageViewUtils.newPadWithPaperType(function() {
+          simplePageViewUtils.newPadWithPaperSize(function() {
             utils.disablePagination();
 
             // load original pad, the one with page breaks
             helper.newPad(done, padId);
-          }, PAPER);
+          }, PAPER_SZE);
         }, 1000);
       });
 
@@ -119,11 +119,11 @@ describe.skip('ep_script_page_view - Enable / Disable automatic pagination', fun
 
     it('loads new pads with pagination disabled', function(done) {
       // load a new pad
-      simplePageViewUtils.newPadWithPaperType(function() {
+      simplePageViewUtils.newPadWithPaperSize(function() {
         var $paginationSetting = helper.padChrome$('#options-pagination');
         expect($paginationSetting.prop('checked')).to.be(false);
         done();
-      }, PAPER);
+      }, PAPER_SZE);
 
       this.timeout(60000);
     });

--- a/static/tests/frontend/specs/lineNumberHeight.js
+++ b/static/tests/frontend/specs/lineNumberHeight.js
@@ -2,10 +2,10 @@
 // https://trello.com/c/hdZGr9EA/684
 describe.skip("ep_script_page_view - height of line numbers", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var utils;
@@ -16,9 +16,9 @@ describe.skip("ep_script_page_view - height of line numbers", function() {
 
   beforeEach(function(done){
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(function() {
+    simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(done);
-    }, PAPER);
+    }, PAPER_SZE);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/otherMoreContd.js
+++ b/static/tests/frontend/specs/otherMoreContd.js
@@ -1,9 +1,9 @@
 describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var utils, scriptBuilder, lastLineText;
@@ -14,11 +14,11 @@ describe.skip("ep_script_page_view - other MORE/CONT'D tests", function() {
 
   beforeEach(function(cb){
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(function() {
+    simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(function() {
         utils.createScriptWith(scriptBuilder(), lastLineText, cb);
       });
-    }, PAPER);
+    }, PAPER_SZE);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/repaginate.js
+++ b/static/tests/frontend/specs/repaginate.js
@@ -1,9 +1,9 @@
 describe.skip("ep_script_page_view - repaginate", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var utils, smUtils;
@@ -15,9 +15,9 @@ describe.skip("ep_script_page_view - repaginate", function() {
 
   beforeEach(function(done){
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(function() {
+    simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(done);
-    }, PAPER);
+    }, PAPER_SZE);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/scroll.js
+++ b/static/tests/frontend/specs/scroll.js
@@ -1,9 +1,9 @@
 describe.skip("ep_script_page_view - scroll", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SIZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SIZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   var utils;
@@ -14,9 +14,9 @@ describe.skip("ep_script_page_view - scroll", function() {
 
   beforeEach(function(done){
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(function() {
+    simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(done);
-    }, PAPER);
+    }, PAPER_SIZE);
     this.timeout(60000);
   });
 

--- a/static/tests/frontend/specs/splitElements.js
+++ b/static/tests/frontend/specs/splitElements.js
@@ -1,9 +1,9 @@
 describe.skip("ep_script_page_view - pagination of split elements", function() {
   // Letter
-  // var PAPER = 'Letter';
+  // var PAPER_SZE = 'Letter';
   // var GENERALS_PER_PAGE = 54;
   // A4
-  var PAPER = 'A4';
+  var PAPER_SZE = 'A4';
   var GENERALS_PER_PAGE = 58;
 
   // shortcuts for helper functions
@@ -18,7 +18,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
   beforeEach(function(cb){
     var simplePageViewUtils = ep_script_simple_page_view_test_helper.utils;
-    simplePageViewUtils.newPadWithPaperType(function() {
+    simplePageViewUtils.newPadWithPaperSize(function() {
       utils.cleanPad(function() {
         var generals      = utils.buildScriptWithGenerals("general", linesBeforeTargetElement);
         var targetElement = buildTargetElement();
@@ -27,7 +27,7 @@ describe.skip("ep_script_page_view - pagination of split elements", function() {
 
         utils.createScriptWith(script, "last general", cb);
       });
-    }, PAPER);
+    }, PAPER_SZE);
     this.timeout(60000);
   });
 


### PR DESCRIPTION
This PR renames the term `paper type` to `paper size`, following the
[international standard](https://www.papersizes.org).

It's related to [card 3038](https://trello.com/c/QTRYv7zw).